### PR TITLE
feat: add daily game score submission

### DIFF
--- a/hubdle/src/lib/parsers.ts
+++ b/hubdle/src/lib/parsers.ts
@@ -1,0 +1,43 @@
+type ParseResult = {
+	gameId: string;
+	score: number;
+	gameDate: string;
+} | null;
+
+export function parseShareText(text: string): ParseResult {
+	return parseWordle(text) ?? parseBandle(text);
+}
+
+function parseWordle(text: string): ParseResult {
+	// "Wordle 1,234 3/6" or "Wordle 1,234 X/6"
+	const match = text.match(/Wordle\s+([\d,]+)\s+([X\d])\/6/);
+	if (!match) return null;
+
+	const puzzleNumber = parseInt(match[1].replace(/,/g, ''), 10);
+	const raw = match[2];
+	const score = raw === 'X' ? 7 : parseInt(raw, 10);
+
+	// Wordle #0 was 2021-06-19. Each puzzle number is one day after.
+	const epoch = new Date('2021-06-19');
+	epoch.setDate(epoch.getDate() + puzzleNumber);
+	const gameDate = epoch.toISOString().slice(0, 10);
+
+	return { gameId: 'wordle', score, gameDate };
+}
+
+function parseBandle(text: string): ParseResult {
+	// "Bandle #123 1/6" or "Bandle #123 x/6"
+	const match = text.match(/Bandle\s+#(\d+)\s+([x\d])\/6/i);
+	if (!match) return null;
+
+	const puzzleNumber = parseInt(match[1], 10);
+	const raw = match[2].toLowerCase();
+	const score = raw === 'x' ? 7 : parseInt(raw, 10);
+
+	// Bandle #1 was 2023-09-12
+	const epoch = new Date('2023-09-11');
+	epoch.setDate(epoch.getDate() + puzzleNumber);
+	const gameDate = epoch.toISOString().slice(0, 10);
+
+	return { gameId: 'bandle', score, gameDate };
+}

--- a/hubdle/src/routes/groups/[id]/+page.server.ts
+++ b/hubdle/src/routes/groups/[id]/+page.server.ts
@@ -1,5 +1,6 @@
-import { error, redirect } from '@sveltejs/kit';
-import type { PageServerLoad } from './$types';
+import { error, fail, redirect } from '@sveltejs/kit';
+import { parseShareText } from '$lib/parsers';
+import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
 	const { user } = await locals.safeGetSession();
@@ -46,5 +47,39 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		.map(([userId, data]) => ({ userId, ...data }))
 		.sort((a, b) => a.total - b.total);
 
-	return { group, members: members ?? [], leaderboard, submissions: submissions ?? [] };
+	const { data: games } = await locals.supabase.from('games').select('id, name, url');
+
+	return { group, members: members ?? [], leaderboard, submissions: submissions ?? [], games: games ?? [] };
+};
+
+export const actions: Actions = {
+	submit: async ({ request, params, locals }) => {
+		const { user } = await locals.safeGetSession();
+		if (!user) redirect(303, '/login');
+
+		const formData = await request.formData();
+		const rawText = (formData.get('raw_text') as string)?.trim();
+
+		if (!rawText) return fail(400, { error: 'Paste your share text.' });
+
+		const parsed = parseShareText(rawText);
+		if (!parsed) return fail(400, { error: 'Could not parse that share text. Supported games: Wordle, Bandle.' });
+
+		const { error: insertError } = await locals.supabase.from('submissions').insert({
+			user_id: user.id,
+			group_id: params.id,
+			game_id: parsed.gameId,
+			score: parsed.score,
+			raw_text: rawText,
+			game_date: parsed.gameDate
+		});
+
+		if (insertError) {
+			if (insertError.code === '23505')
+				return fail(409, { error: 'You already submitted a score for this game today.' });
+			return fail(500, { error: `Failed to submit: ${insertError.message}` });
+		}
+
+		return { success: true };
+	}
 };

--- a/hubdle/src/routes/groups/[id]/+page.svelte
+++ b/hubdle/src/routes/groups/[id]/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import type { PageData } from './$types';
+	import { enhance } from '$app/forms';
+	import type { ActionData, PageData } from './$types';
 
-	let { data }: { data: PageData } = $props();
+	let { data, form }: { data: PageData; form: ActionData } = $props();
 </script>
 
 <div class="mx-auto max-w-2xl p-6">
@@ -15,6 +16,32 @@
 			<span class="badge badge-ghost font-mono text-lg">{data.group.invite_code}</span>
 		</div>
 	</div>
+
+	<section class="mt-8">
+		<h2 class="text-lg font-semibold">Submit Score</h2>
+		<form method="POST" action="?/submit" use:enhance class="mt-3 flex flex-col gap-3">
+			<textarea
+				name="raw_text"
+				placeholder="Paste your share text here (e.g. Wordle 1,234 3/6)"
+				class="textarea textarea-bordered w-full"
+				rows="3"
+				required
+			></textarea>
+			<button class="btn btn-primary w-fit">Submit</button>
+		</form>
+
+		{#if form?.error}
+			<div class="alert alert-error mt-3">
+				<span>{form.error}</span>
+			</div>
+		{/if}
+
+		{#if form?.success}
+			<div class="alert alert-success mt-3">
+				<span>Score submitted!</span>
+			</div>
+		{/if}
+	</section>
 
 	<section class="mt-8">
 		<h2 class="text-lg font-semibold">Leaderboard</h2>
@@ -39,6 +66,37 @@
 								<td>{entry.username}</td>
 								<td>{entry.games}</td>
 								<td>{entry.total}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	</section>
+
+	<section class="mt-8">
+		<h2 class="text-lg font-semibold">Recent Submissions</h2>
+		{#if data.submissions.length === 0}
+			<p class="mt-2 opacity-70">No submissions yet.</p>
+		{:else}
+			<div class="mt-4 overflow-x-auto">
+				<table class="table">
+					<thead>
+						<tr>
+							<th>Player</th>
+							<th>Game</th>
+							<th>Score</th>
+							<th>Date</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each data.submissions as sub}
+							{@const member = data.members.find((m) => m.user_id === sub.user_id)}
+							<tr>
+								<td>{member?.profiles?.username ?? 'Unknown'}</td>
+								<td>{sub.games?.name ?? sub.game_id}</td>
+								<td>{sub.score}</td>
+								<td>{sub.game_date}</td>
 							</tr>
 						{/each}
 					</tbody>


### PR DESCRIPTION
## Summary
- Add share text parsers for Wordle (`Wordle 1,234 3/6`) and Bandle (`Bandle #123 1/6`)
- Add score submission form on group detail page — paste share text, game is auto-detected
- Show recent submissions table (player, game, score, date) on group page
- Duplicate submissions per user/game/day are rejected with a clear error

## Test plan
- [x] Paste a Wordle share text and verify score is parsed and submitted
- [ ] Paste a Bandle share text and verify score is parsed and submitted
- [ ] Verify duplicate submission for same game/day is rejected
- [ ] Verify invalid/unsupported share text shows parse error
- [x] Verify leaderboard updates after submission
- [x] Verify recent submissions table shows correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)