### PR TITLE
feat: add leave and delete group functionality

### DIFF
--- a/hubdle/src/routes/groups/[id]/+page.server.ts
+++ b/hubdle/src/routes/groups/[id]/+page.server.ts
@@ -27,7 +27,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 
 	const { data: games } = await locals.supabase.from('games').select('id, name, url');
 
-	return { group, members: members ?? [], submissions: submissions ?? [], games: games ?? [] };
+	return { group, members: members ?? [], submissions: submissions ?? [], games: games ?? [], userId: user.id };
 };
 
 export const actions: Actions = {
@@ -59,5 +59,45 @@ export const actions: Actions = {
 		}
 
 		return { success: true };
+	},
+
+	leave: async ({ params, locals }) => {
+		const { user } = await locals.safeGetSession();
+		if (!user) redirect(303, '/login');
+
+		const { error: deleteError } = await locals.supabase
+			.from('group_members')
+			.delete()
+			.eq('group_id', params.id)
+			.eq('user_id', user.id);
+
+		if (deleteError) return fail(500, { error: `Failed to leave group: ${deleteError.message}` });
+
+		redirect(303, '/groups');
+	},
+
+	delete: async ({ params, locals }) => {
+		const { user } = await locals.safeGetSession();
+		if (!user) redirect(303, '/login');
+
+		// Verify the user is the creator
+		const { data: group } = await locals.supabase
+			.from('groups')
+			.select('created_by')
+			.eq('id', params.id)
+			.single();
+
+		if (!group || group.created_by !== user.id) {
+			return fail(403, { error: 'Only the group creator can delete this group.' });
+		}
+
+		const { error: deleteError } = await locals.supabase
+			.from('groups')
+			.delete()
+			.eq('id', params.id);
+
+		if (deleteError) return fail(500, { error: `Failed to delete group: ${deleteError.message}` });
+
+		redirect(303, '/groups');
 	}
 };

--- a/hubdle/src/routes/groups/[id]/+page.svelte
+++ b/hubdle/src/routes/groups/[id]/+page.svelte
@@ -198,4 +198,33 @@
 			{/each}
 		</div>
 	</section>
+
+	<section class="mt-12 flex gap-3 border-t border-base-300 pt-6">
+		<form method="POST" action="?/leave" use:enhance>
+			<button
+				type="submit"
+				class="btn btn-ghost"
+				onclick={(e) => {
+					if (!confirm('Are you sure you want to leave this group?')) e.preventDefault();
+				}}
+			>
+				Leave Group
+			</button>
+		</form>
+
+		{#if data.userId === data.group.created_by}
+			<form method="POST" action="?/delete" use:enhance>
+				<button
+					type="submit"
+					class="btn btn-error"
+					onclick={(e) => {
+						if (!confirm('Are you sure you want to delete this group? This cannot be undone.'))
+							e.preventDefault();
+					}}
+				>
+					Delete Group
+				</button>
+			</form>
+		{/if}
+	</section>
 </div>

--- a/hubdle/supabase/migrations/00002_group_management_policies.sql
+++ b/hubdle/supabase/migrations/00002_group_management_policies.sql
@@ -1,0 +1,9 @@
+-- Delete policy for groups: only the creator can delete
+create policy "Creator can delete group"
+  on public.groups for delete
+  using (auth.uid() = created_by);
+
+-- Delete policy for group_members: members can remove themselves
+create policy "Members can remove themselves"
+  on public.group_members for delete
+  using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- Add "Leave Group" button (btn-ghost) on group detail page for any member to remove themselves from the group, with confirmation dialog
- Add "Delete Group" button (btn-error) visible only to the group creator, with confirmation dialog; cascades to group_members and submissions via FK
- Add RLS migration (`00002_group_management_policies.sql`) with delete policies for `groups` (creator only) and `group_members` (self-removal)
- Pass `userId` from server load to page for creator check

## Test plan
- [x] As a group member (non-creator), verify "Leave Group" button is visible and "Delete Group" is hidden
- [x] Click "Leave Group", confirm the dialog, verify redirect to /groups and membership removed
- [x] As the group creator, verify both "Leave Group" and "Delete Group" buttons are visible
- [x] Click "Delete Group", confirm the dialog, verify redirect to /groups and group is fully deleted
- [x] Verify RLS policies: non-creator cannot delete a group via direct API call
- [x] Verify RLS policies: user cannot remove another user's group_members row

🤖 Generated with [Claude Code](https://claude.com/claude-code)