### PR TITLE
feat: add per-game leaderboards and time filters

### DIFF
--- a/hubdle/src/routes/groups/[id]/+page.server.ts
+++ b/hubdle/src/routes/groups/[id]/+page.server.ts
@@ -25,31 +25,9 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		.eq('group_id', params.id)
 		.order('game_date', { ascending: false });
 
-	// Build leaderboard: total score per user across all games
-	const scores = new Map<string, { username: string; total: number; games: number }>();
-
-	for (const member of members ?? []) {
-		const profile = member.profiles;
-		if (profile) {
-			scores.set(member.user_id, { username: profile.username, total: 0, games: 0 });
-		}
-	}
-
-	for (const sub of submissions ?? []) {
-		const entry = scores.get(sub.user_id);
-		if (entry) {
-			entry.total += sub.score;
-			entry.games += 1;
-		}
-	}
-
-	const leaderboard = [...scores.entries()]
-		.map(([userId, data]) => ({ userId, ...data }))
-		.sort((a, b) => a.total - b.total);
-
 	const { data: games } = await locals.supabase.from('games').select('id, name, url');
 
-	return { group, members: members ?? [], leaderboard, submissions: submissions ?? [], games: games ?? [] };
+	return { group, members: members ?? [], submissions: submissions ?? [], games: games ?? [] };
 };
 
 export const actions: Actions = {

--- a/hubdle/src/routes/groups/[id]/+page.svelte
+++ b/hubdle/src/routes/groups/[id]/+page.svelte
@@ -3,6 +3,49 @@
 	import type { ActionData, PageData } from './$types';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	type TimeFilter = 'all' | 'weekly' | 'daily';
+
+	let selectedGame = $state<string>('all');
+	let selectedTime = $state<TimeFilter>('all');
+
+	let filteredLeaderboard = $derived.by(() => {
+		const now = new Date();
+		const todayStr = now.toISOString().slice(0, 10);
+		const weekAgo = new Date(now);
+		weekAgo.setDate(weekAgo.getDate() - 7);
+		const weekAgoStr = weekAgo.toISOString().slice(0, 10);
+
+		// Filter submissions by game and time
+		const filtered = (data.submissions ?? []).filter((sub) => {
+			if (selectedGame !== 'all' && sub.game_id !== selectedGame) return false;
+			if (selectedTime === 'daily' && sub.game_date !== todayStr) return false;
+			if (selectedTime === 'weekly' && sub.game_date < weekAgoStr) return false;
+			return true;
+		});
+
+		// Build scores map from members
+		const scores = new Map<string, { username: string; total: number; games: number }>();
+		for (const member of data.members ?? []) {
+			const profile = member.profiles;
+			if (profile) {
+				scores.set(member.user_id, { username: profile.username, total: 0, games: 0 });
+			}
+		}
+
+		for (const sub of filtered) {
+			const entry = scores.get(sub.user_id);
+			if (entry) {
+				entry.total += sub.score;
+				entry.games += 1;
+			}
+		}
+
+		return [...scores.entries()]
+			.map(([userId, d]) => ({ userId, ...d }))
+			.filter((e) => e.games > 0)
+			.sort((a, b) => a.total - b.total);
+	});
 </script>
 
 <div class="mx-auto max-w-2xl p-6">
@@ -46,8 +89,50 @@
 	<section class="mt-8">
 		<h2 class="text-lg font-semibold">Leaderboard</h2>
 
-		{#if data.leaderboard.length === 0}
-			<p class="mt-2 opacity-70">No scores yet.</p>
+		<!-- Game filter tabs -->
+		<div role="tablist" class="tabs tabs-bordered mt-4">
+			<button
+				role="tab"
+				class="tab {selectedGame === 'all' ? 'tab-active' : ''}"
+				onclick={() => (selectedGame = 'all')}
+			>
+				All Games
+			</button>
+			{#each data.games as game}
+				<button
+					role="tab"
+					class="tab {selectedGame === game.id ? 'tab-active' : ''}"
+					onclick={() => (selectedGame = game.id)}
+				>
+					{game.name}
+				</button>
+			{/each}
+		</div>
+
+		<!-- Time filter -->
+		<div class="mt-3 flex gap-1">
+			<button
+				class="btn btn-sm {selectedTime === 'all' ? 'btn-active' : 'btn-ghost'}"
+				onclick={() => (selectedTime = 'all')}
+			>
+				All Time
+			</button>
+			<button
+				class="btn btn-sm {selectedTime === 'weekly' ? 'btn-active' : 'btn-ghost'}"
+				onclick={() => (selectedTime = 'weekly')}
+			>
+				Weekly
+			</button>
+			<button
+				class="btn btn-sm {selectedTime === 'daily' ? 'btn-active' : 'btn-ghost'}"
+				onclick={() => (selectedTime = 'daily')}
+			>
+				Today
+			</button>
+		</div>
+
+		{#if filteredLeaderboard.length === 0}
+			<p class="mt-4 opacity-70">No scores yet for this selection.</p>
 		{:else}
 			<div class="mt-4 overflow-x-auto">
 				<table class="table">
@@ -60,7 +145,7 @@
 						</tr>
 					</thead>
 					<tbody>
-						{#each data.leaderboard as entry, i}
+						{#each filteredLeaderboard as entry, i}
 							<tr class={i === 0 ? 'bg-base-200 font-semibold' : ''}>
 								<td>{i + 1}</td>
 								<td>{entry.username}</td>


### PR DESCRIPTION
## Summary
- Add per-game leaderboard tabs (All Games, Wordle, Bandle) using DaisyUI tabs on the group detail page
- Add time period filter buttons (All Time, Weekly, Today) using DaisyUI btn-group style
- Move leaderboard computation from server to client using Svelte 5 `$derived` rune for instant filtering without page reloads

## Test plan
- [x] Verify "All Games" tab shows combined leaderboard across all games
- [x] Verify clicking a specific game tab (e.g. Wordle) filters to only that game's scores
- [x] Verify "Today" filter shows only scores from today's date
- [x] Verify "Weekly" filter shows scores from the last 7 days
- [x] Verify "All Time" shows all scores (default)
- [x] Verify combining game + time filters works correctly (e.g. Wordle + Weekly)
- [x] Verify empty state message appears when no scores match the selected filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)