### PR TITLE
fix: center login card vertically within viewport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@ Thumbs.db
 # Claude Code (track rules, ignore local settings)
 .claude/settings.local.json
 
+# Local planning notes
+plans/
+
+# Playwright MCP screenshots
+.playwright-mcp/
+
 # Node (root level safety)
 node_modules
 

--- a/hubdle/src/routes/+layout.svelte
+++ b/hubdle/src/routes/+layout.svelte
@@ -17,7 +17,7 @@
 	<link rel="icon" href={favicon} />
 </svelte:head>
 
-<div class="flex min-h-screen flex-col">
+<div class="grid h-screen grid-rows-[auto_1fr]">
 	<nav class="navbar bg-base-200 px-4">
 		<div class="flex-1 gap-4">
 			<a href="/" class="text-xl font-bold">Hubdle</a>
@@ -35,7 +35,7 @@
 		</div>
 	</nav>
 
-	<main class="flex-1">
+	<main class="h-full overflow-y-auto">
 		{@render children()}
 	</main>
 </div>

--- a/hubdle/src/routes/login/+page.svelte
+++ b/hubdle/src/routes/login/+page.svelte
@@ -50,7 +50,7 @@
 	}
 </script>
 
-<div class="flex min-h-screen items-center justify-center">
+<div class="flex h-full items-center justify-center">
 	<div class="card w-full max-w-sm bg-base-200 shadow-xl">
 		<div class="card-body">
 			<h2 class="card-title justify-center text-2xl">


### PR DESCRIPTION
## Summary
- Replace `min-h-screen` with `h-screen` on the layout grid container — this gives the grid a definite height so the `1fr` row resolves correctly
- Add `h-full overflow-y-auto` to `<main>` so it fills the grid row (and still scrolls on content-heavy pages)
- Update login page wrapper from `min-h-screen` to `h-full` to inherit from the properly-sized parent
- Add `.playwright-mcp/` to `.gitignore`

## Test plan
- [x] Visit `/login` — card should be vertically centered in the area below the navbar
- [x] Visit other pages — no layout regressions, content-heavy pages still scroll normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)