### PR TITLE
fix: redirect authenticated users from landing page to /groups

### DIFF
--- a/hubdle/src/routes/+page.server.ts
+++ b/hubdle/src/routes/+page.server.ts
@@ -1,0 +1,7 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	const { user } = await locals.safeGetSession();
+	if (user) redirect(303, '/groups');
+};


### PR DESCRIPTION
## Summary
- Add `+page.server.ts` to the root route that redirects authenticated users straight to `/groups`
- Unauthenticated users still see the landing/marketing page

## Test plan
- [ ] While logged out: `/` shows the landing page
- [ ] While logged in: `/` redirects to `/groups`

🤖 Generated with [Claude Code](https://claude.com/claude-code)