### PR TITLE
feat: add copy invite code button

### DIFF
--- a/hubdle/src/routes/groups/+page.svelte
+++ b/hubdle/src/routes/groups/+page.svelte
@@ -5,6 +5,16 @@
 	import Alert from '$lib/components/Alert.svelte';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	let copiedId = $state<string | null>(null);
+
+	async function copyCode(e: MouseEvent, code: string, id: string) {
+		e.preventDefault();
+		e.stopPropagation();
+		await navigator.clipboard.writeText(code);
+		copiedId = id;
+		setTimeout(() => (copiedId = null), 1500);
+	}
 </script>
 
 <PageContainer>
@@ -46,7 +56,13 @@
 				<a href="/groups/{group.id}" class="card bg-base-200 shadow transition hover:shadow-lg">
 					<div class="card-body flex-row items-center justify-between">
 						<h2 class="card-title">{group.name}</h2>
-						<span class="badge badge-ghost font-mono">{group.invite_code}</span>
+						<button
+							class="flex items-center gap-1 font-mono text-sm opacity-70 hover:opacity-100"
+							onclick={(e) => copyCode(e, group.invite_code, group.id)}
+						>
+							<span class="badge badge-ghost font-mono">{group.invite_code}</span>
+							<span class="text-xs">{copiedId === group.id ? 'Copied!' : 'Copy'}</span>
+						</button>
 					</div>
 				</a>
 			{/each}

--- a/hubdle/src/routes/groups/[id]/+page.svelte
+++ b/hubdle/src/routes/groups/[id]/+page.svelte
@@ -7,6 +7,14 @@
 	import RecentSubmissions from '$lib/components/RecentSubmissions.svelte';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	let copied = $state(false);
+
+	async function copyCode() {
+		await navigator.clipboard.writeText(data.group.invite_code);
+		copied = true;
+		setTimeout(() => (copied = false), 1500);
+	}
 </script>
 
 <PageContainer>
@@ -17,7 +25,10 @@
 		</div>
 		<div class="text-right">
 			<p class="text-xs opacity-50">Invite code</p>
-			<span class="badge badge-ghost font-mono text-lg">{data.group.invite_code}</span>
+			<button class="flex items-center gap-2" onclick={copyCode}>
+				<span class="badge badge-ghost font-mono text-lg">{data.group.invite_code}</span>
+				<span class="text-xs opacity-70">{copied ? 'Copied!' : 'Copy'}</span>
+			</button>
 		</div>
 	</div>
 


### PR DESCRIPTION
## Summary
- Groups list: each group card gets a copy button next to the invite code badge (click stops navigation to the group)
- Group detail: copy button next to the invite code in the header
- Both show "Copied!" feedback for 1.5s after clicking

## Test plan
- [ ] Groups list: clicking "Copy" copies the code and shows "Copied!" without navigating
- [ ] Group detail: clicking "Copy" next to the invite code badge copies and shows "Copied!"

🤖 Generated with [Claude Code](https://claude.com/claude-code)