### PR TITLE
feat: improve form feedback

### DIFF
--- a/hubdle/src/lib/components/ScoreSubmitForm.svelte
+++ b/hubdle/src/lib/components/ScoreSubmitForm.svelte
@@ -3,6 +3,12 @@
 	import Alert from './Alert.svelte';
 
 	let { form }: { form: { error?: string; success?: boolean } | null } = $props();
+
+	let rawText = $state('');
+
+	$effect(() => {
+		if (form?.success) rawText = '';
+	});
 </script>
 
 <section class="mt-8">
@@ -14,6 +20,7 @@
 			class="textarea textarea-bordered w-full"
 			rows="3"
 			required
+			bind:value={rawText}
 		></textarea>
 		<button class="btn btn-primary w-fit">Submit</button>
 	</form>

--- a/hubdle/src/routes/login/+page.svelte
+++ b/hubdle/src/routes/login/+page.svelte
@@ -8,10 +8,12 @@
 	let isSignUp = $state(false);
 	let loading = $state(false);
 	let error = $state('');
+	let signUpSuccess = $state(false);
 
 	async function handleSubmit() {
 		loading = true;
 		error = '';
+		signUpSuccess = false;
 
 		const { supabase } = data;
 
@@ -24,8 +26,7 @@
 			if (err) {
 				error = err.message;
 			} else {
-				error = '';
-				alert('Check your email for a confirmation link.');
+				signUpSuccess = true;
 			}
 		} else {
 			const { error: err, data: signInData } = await supabase.auth.signInWithPassword({
@@ -83,6 +84,9 @@
 
 				{#if error}
 					<p class="text-error text-sm">{error}</p>
+				{/if}
+				{#if signUpSuccess}
+					<p class="text-success text-sm">Check your email for a confirmation link.</p>
 				{/if}
 
 				<button class="btn btn-primary w-full" disabled={loading}>


### PR DESCRIPTION
## Summary
- Login page: replace native `alert()` on sign-up with an in-page success message
- Score submit form: textarea now clears automatically after a successful submission (via `$effect` watching `form.success`)

## Test plan
- [ ] Sign up with a new email: success message appears inline instead of a browser alert dialog
- [x] Submit a score: textarea clears after success alert appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)