### PR TITLE
refactor: extract NavLink component for active-aware nav links

### DIFF
--- a/hubdle/src/lib/components/NavLink.svelte
+++ b/hubdle/src/lib/components/NavLink.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+
+	let { href, label }: { href: string; label: string } = $props();
+</script>
+
+<a {href} class="btn btn-ghost btn-sm {$page.url.pathname.startsWith(href) ? 'btn-active' : ''}">
+	{label}
+</a>

--- a/hubdle/src/routes/+layout.svelte
+++ b/hubdle/src/routes/+layout.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import favicon from '$lib/assets/favicon.svg';
 	import { goto } from '$app/navigation';
-	import { page } from '$app/stores';
 	import '../app.css';
+	import NavLink from '$lib/components/NavLink.svelte';
 
 	import type { LayoutData } from './$types';
 
@@ -23,7 +23,7 @@
 		<div class="flex-1 gap-4">
 			<a href="/" class="text-xl font-bold">Hubdle</a>
 			{#if data.user}
-				<a href="/groups" class="btn btn-ghost btn-sm {$page.url.pathname.startsWith('/groups') ? 'btn-active' : ''}">Groups</a>
+				<NavLink href="/groups" label="Groups" />
 			{/if}
 		</div>
 		<div class="flex-none">


### PR DESCRIPTION
## Summary
- Add `NavLink.svelte` — encapsulates the `$page` import and `btn-active` logic
- Layout now uses `<NavLink href="/groups" label="Groups" />` instead of the inline active-class expression
- Adding future nav links is just one more `<NavLink>` line

## Test plan
- [ ] `/groups` and `/groups/[id]` — Groups link is active
- [ ] Other pages — Groups link is not active

🤖 Generated with [Claude Code](https://claude.com/claude-code)