### PR TITLE
feat: wrap group detail sections in cards for visual separation

### DIFF
--- a/hubdle/src/lib/components/Leaderboard.svelte
+++ b/hubdle/src/lib/components/Leaderboard.svelte
@@ -49,10 +49,11 @@
 	});
 </script>
 
-<section class="mt-8">
-	<h2 class="text-lg font-semibold">Leaderboard</h2>
+<section class="card mt-6 bg-base-200">
+	<div class="card-body">
+	<h2 class="card-title text-base">Leaderboard</h2>
 
-	<div role="tablist" class="tabs tabs-bordered mt-4">
+	<div role="tablist" class="tabs tabs-bordered mt-2">
 		<button
 			role="tab"
 			class="tab {selectedGame === 'all' ? 'tab-active' : ''}"
@@ -107,7 +108,7 @@
 				</thead>
 				<tbody>
 					{#each filteredLeaderboard as entry, i}
-						<tr class={i === 0 ? 'bg-base-200 font-semibold' : ''}>
+						<tr class={i === 0 ? 'bg-base-300 font-semibold' : ''}>
 							<td>{i + 1}</td>
 							<td>{entry.username}</td>
 							<td>{entry.games}</td>
@@ -118,4 +119,5 @@
 			</table>
 		</div>
 	{/if}
+	</div>
 </section>

--- a/hubdle/src/lib/components/RecentSubmissions.svelte
+++ b/hubdle/src/lib/components/RecentSubmissions.svelte
@@ -11,33 +11,35 @@
 	let { submissions, members }: { submissions: Submission[]; members: Member[] } = $props();
 </script>
 
-<section class="mt-8">
-	<h2 class="text-lg font-semibold">Recent Submissions</h2>
-	{#if submissions.length === 0}
-		<p class="mt-2 opacity-70">No submissions yet.</p>
-	{:else}
-		<div class="mt-4 overflow-x-auto">
-			<table class="table">
-				<thead>
-					<tr>
-						<th>Player</th>
-						<th>Game</th>
-						<th>Score</th>
-						<th>Date</th>
-					</tr>
-				</thead>
-				<tbody>
-					{#each submissions as sub}
-						{@const member = members.find((m) => m.user_id === sub.user_id)}
+<section class="card mt-6 bg-base-200">
+	<div class="card-body">
+		<h2 class="card-title text-base">Recent Submissions</h2>
+		{#if submissions.length === 0}
+			<p class="opacity-70">No submissions yet.</p>
+		{:else}
+			<div class="overflow-x-auto">
+				<table class="table">
+					<thead>
 						<tr>
-							<td>{member?.profiles?.username ?? 'Unknown'}</td>
-							<td>{sub.games?.name ?? sub.game_id}</td>
-							<td>{sub.score}</td>
-							<td>{sub.game_date}</td>
+							<th>Player</th>
+							<th>Game</th>
+							<th>Score</th>
+							<th>Date</th>
 						</tr>
-					{/each}
-				</tbody>
-			</table>
-		</div>
-	{/if}
+					</thead>
+					<tbody>
+						{#each submissions as sub}
+							{@const member = members.find((m) => m.user_id === sub.user_id)}
+							<tr>
+								<td>{member?.profiles?.username ?? 'Unknown'}</td>
+								<td>{sub.games?.name ?? sub.game_id}</td>
+								<td>{sub.score}</td>
+								<td>{sub.game_date}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	</div>
 </section>

--- a/hubdle/src/lib/components/ScoreSubmitForm.svelte
+++ b/hubdle/src/lib/components/ScoreSubmitForm.svelte
@@ -11,24 +11,26 @@
 	});
 </script>
 
-<section class="mt-8">
-	<h2 class="text-lg font-semibold">Submit Score</h2>
-	<form method="POST" action="?/submit" use:enhance class="mt-3 flex flex-col gap-3">
-		<textarea
-			name="raw_text"
-			placeholder="Paste your share text here (e.g. Wordle 1,234 3/6)"
-			class="textarea textarea-bordered w-full"
-			rows="3"
-			required
-			bind:value={rawText}
-		></textarea>
-		<button class="btn btn-primary w-fit">Submit</button>
-	</form>
+<section class="card mt-6 bg-base-200">
+	<div class="card-body">
+		<h2 class="card-title text-base">Submit Score</h2>
+		<form method="POST" action="?/submit" use:enhance class="flex flex-col gap-3">
+			<textarea
+				name="raw_text"
+				placeholder="Paste your share text here (e.g. Wordle 1,234 3/6)"
+				class="textarea textarea-bordered w-full"
+				rows="3"
+				required
+				bind:value={rawText}
+			></textarea>
+			<button class="btn btn-primary w-fit">Submit</button>
+		</form>
 
-	{#if form?.error}
-		<Alert type="error" message={form.error} />
-	{/if}
-	{#if form?.success}
-		<Alert type="success" message="Score submitted!" />
-	{/if}
+		{#if form?.error}
+			<Alert type="error" message={form.error} />
+		{/if}
+		{#if form?.success}
+			<Alert type="success" message="Score submitted!" />
+		{/if}
+	</div>
 </section>


### PR DESCRIPTION
## Summary
- `ScoreSubmitForm`, `Leaderboard`, and `RecentSubmissions` now render inside DaisyUI `card` wrappers instead of plain `<section>` tags
- First-place leaderboard row uses `bg-base-300` (was `bg-base-200`, invisible against the card background)

## Test plan
- [x] Group detail page — three main sections are visually distinct cards
- [x] Leaderboard — top entry has a visible highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)