### PR TITLE
feat: improve empty state messages

### DIFF
--- a/hubdle/src/lib/components/Leaderboard.svelte
+++ b/hubdle/src/lib/components/Leaderboard.svelte
@@ -94,7 +94,11 @@
 	</div>
 
 	{#if filteredLeaderboard.length === 0}
-		<p class="mt-4 opacity-70">No scores yet for this selection.</p>
+		<p class="mt-4 opacity-70">
+			{selectedGame === 'all' && selectedTime === 'all'
+				? 'No scores yet — submit one above to get started!'
+				: 'No scores for this selection.'}
+		</p>
 	{:else}
 		<div class="mt-4 overflow-x-auto">
 			<table class="table">

--- a/hubdle/src/lib/components/RecentSubmissions.svelte
+++ b/hubdle/src/lib/components/RecentSubmissions.svelte
@@ -15,7 +15,7 @@
 	<div class="card-body">
 		<h2 class="card-title text-base">Recent Submissions</h2>
 		{#if submissions.length === 0}
-			<p class="opacity-70">No submissions yet.</p>
+			<p class="opacity-70">No submissions yet — paste a share text above to submit your first score.</p>
 		{:else}
 			<div class="overflow-x-auto">
 				<table class="table">

--- a/hubdle/src/routes/groups/+page.svelte
+++ b/hubdle/src/routes/groups/+page.svelte
@@ -49,7 +49,11 @@
 	</div>
 
 	{#if data.groups.length === 0}
-		<p class="mt-8 opacity-70">You're not in any groups yet. Create one or join with an invite code.</p>
+		<div class="mt-12 flex flex-col items-center gap-3 text-center opacity-60">
+			<p class="text-4xl">🏆</p>
+			<p class="font-medium">No groups yet</p>
+			<p class="text-sm">Create a group to get started, or join one with an invite code above.</p>
+		</div>
 	{:else}
 		<div class="mt-8 grid gap-4">
 			{#each data.groups as group}


### PR DESCRIPTION
## Summary
- Groups page: centered trophy icon + clearer copy when no groups exist
- Leaderboard: distinguishes between "truly empty" (suggests submitting a score) vs filtered-to-empty ("no scores for this selection")
- Recent submissions: points the user toward the submit form above

## Test plan
- [ ] Groups page with no groups — trophy icon + guidance text shown
- [ ] Group detail with no submissions — leaderboard and recent submissions show helpful messages
- [ ] Leaderboard with filters applied + no results — shows "No scores for this selection"

🤖 Generated with [Claude Code](https://claude.com/claude-code)