### PR TITLE
fix: use score_direction from games table for leaderboard sorting

### DIFF
--- a/hubdle/src/lib/components/Leaderboard.svelte
+++ b/hubdle/src/lib/components/Leaderboard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	type Game = { id: string; name: string; url: string };
+	type Game = { id: string; name: string; url: string; score_direction: string };
 	type Submission = { user_id: string; score: number; game_id: string; game_date: string };
 	type Member = { user_id: string; profiles: { username: string } | null };
 	type TimeFilter = 'all' | 'weekly' | 'daily';
@@ -42,10 +42,13 @@
 			}
 		}
 
+		const selectedGameData = games.find((g) => g.id === selectedGame);
+		const ascending = selectedGameData ? selectedGameData.score_direction === 'asc' : true;
+
 		return [...scores.entries()]
 			.map(([userId, d]) => ({ userId, ...d }))
 			.filter((e) => e.games > 0)
-			.sort((a, b) => a.total - b.total);
+			.sort((a, b) => ascending ? a.total - b.total : b.total - a.total);
 	});
 </script>
 

--- a/hubdle/src/routes/groups/[id]/+page.server.ts
+++ b/hubdle/src/routes/groups/[id]/+page.server.ts
@@ -25,7 +25,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		.eq('group_id', params.id)
 		.order('game_date', { ascending: false });
 
-	const { data: games } = await locals.supabase.from('games').select('id, name, url');
+	const { data: games } = await locals.supabase.from('games').select('id, name, url, score_direction');
 
 	return { group, members: members ?? [], submissions: submissions ?? [], games: games ?? [], userId: user.id };
 };


### PR DESCRIPTION
## Summary
- Add `score_direction` to the games server query (was missing from the select)
- When a single game is selected, sort by that game's `score_direction` (`asc` = lower is better, anything else = higher is better)
- When "All Games" is selected, keep ascending as the default (both Wordle and Bandle use lower = better)

## Test plan
- [ ] Select a game with `score_direction = 'asc'` — lower scores rank higher
- [ ] Select a game with `score_direction = 'desc'` — higher scores rank higher
- [ ] "All Games" view — still sorts ascending

🤖 Generated with [Claude Code](https://claude.com/claude-code)