### PR TITLE
feat: add Connections and Contexto parsers

### DIFF
--- a/hubdle/src/lib/parsers.ts
+++ b/hubdle/src/lib/parsers.ts
@@ -5,7 +5,7 @@ type ParseResult = {
 } | null;
 
 export function parseShareText(text: string): ParseResult {
-	return parseWordle(text) ?? parseBandle(text);
+	return parseWordle(text) ?? parseBandle(text) ?? parseConnections(text) ?? parseContexto(text);
 }
 
 function parseWordle(text: string): ParseResult {
@@ -40,4 +40,41 @@ function parseBandle(text: string): ParseResult {
 	const gameDate = epoch.toISOString().slice(0, 10);
 
 	return { gameId: 'bandle', score, gameDate };
+}
+
+function parseConnections(text: string): ParseResult {
+	// "Connections\nPuzzle #412\n🟨🟨🟨🟨\n..."
+	const headerMatch = text.match(/Connections\s+Puzzle\s+#(\d+)/i);
+	if (!headerMatch) return null;
+
+	const puzzleNumber = parseInt(headerMatch[1], 10);
+
+	// Count emoji rows — each row is 4 coloured squares
+	const emojiRows = (text.match(/[🟨🟩🟪🟦]{4}/g) ?? []);
+	const totalRows = emojiRows.length;
+	if (totalRows < 4) return null;
+	const score = totalRows - 4; // mistakes
+
+	// Connections puzzle #1 launched 2023-08-12
+	const epoch = new Date('2023-08-11');
+	epoch.setDate(epoch.getDate() + puzzleNumber);
+	const gameDate = epoch.toISOString().slice(0, 10);
+
+	return { gameId: 'connections', score, gameDate };
+}
+
+function parseContexto(text: string): ParseResult {
+	// "I solved Contexto #342 in 23 guesses."
+	const match = text.match(/Contexto\s+#(\d+)\D+?(\d+)\s+guess/i);
+	if (!match) return null;
+
+	const puzzleNumber = parseInt(match[1], 10);
+	const score = parseInt(match[2], 10);
+
+	// Contexto #1 launched 2022-09-19
+	const epoch = new Date('2022-09-18');
+	epoch.setDate(epoch.getDate() + puzzleNumber);
+	const gameDate = epoch.toISOString().slice(0, 10);
+
+	return { gameId: 'contexto', score, gameDate };
 }

--- a/hubdle/src/routes/groups/[id]/+page.server.ts
+++ b/hubdle/src/routes/groups/[id]/+page.server.ts
@@ -41,7 +41,7 @@ export const actions: Actions = {
 		if (!rawText) return fail(400, { error: 'Paste your share text.' });
 
 		const parsed = parseShareText(rawText);
-		if (!parsed) return fail(400, { error: 'Could not parse that share text. Supported games: Wordle, Bandle.' });
+		if (!parsed) return fail(400, { error: 'Could not parse that share text. Supported games: Wordle, Bandle, Connections, Contexto.' });
 
 		const { error: insertError } = await locals.supabase.from('submissions').insert({
 			user_id: user.id,


### PR DESCRIPTION
## Summary
- Add `parseConnections` — parses "Connections\nPuzzle #412\n🟨🟨🟨🟨\n..." share text; score = number of mistakes (total emoji rows − 4)
- Add `parseContexto` — parses "I solved Contexto #342 in 23 guesses." share text; score = number of guesses
- Update error message to list all four supported games

## Notes
- Both games need rows in the Supabase `games` table with `id = 'connections'` / `id = 'contexto'` and appropriate `score_direction` (`asc` for both — fewer mistakes / fewer guesses is better)
- Epoch dates (used to derive `game_date` from puzzle number) are best-guess estimates and may need adjusting:
  - Connections #1 → 2023-08-12
  - Contexto #1 → 2022-09-19

## Test plan
- [ ] Paste a Connections share text → parses correctly, score = mistake count
- [ ] Paste a Contexto share text → parses correctly, score = guess count
- [ ] Paste an unsupported game → error message lists all four games

🤖 Generated with [Claude Code](https://claude.com/claude-code)