### PR TITLE
refactor: extract CopyBadge component for invite code copying

### DIFF
--- a/hubdle/src/lib/components/CopyBadge.svelte
+++ b/hubdle/src/lib/components/CopyBadge.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	let {
+		text,
+		size = 'sm',
+		onclick
+	}: { text: string; size?: 'sm' | 'lg'; onclick?: (e: MouseEvent) => void } = $props();
+
+	let copied = $state(false);
+
+	async function handleClick(e: MouseEvent) {
+		onclick?.(e);
+		await navigator.clipboard.writeText(text);
+		copied = true;
+		setTimeout(() => (copied = false), 1500);
+	}
+</script>
+
+<button
+	class="flex items-center gap-1 opacity-70 hover:opacity-100"
+	onclick={handleClick}
+>
+	<span class="badge badge-ghost font-mono {size === 'lg' ? 'text-lg' : 'text-sm'}">{text}</span>
+	<span class="text-xs">{copied ? 'Copied!' : 'Copy'}</span>
+</button>

--- a/hubdle/src/routes/groups/+page.svelte
+++ b/hubdle/src/routes/groups/+page.svelte
@@ -3,18 +3,9 @@
 	import type { ActionData, PageData } from './$types';
 	import PageContainer from '$lib/components/PageContainer.svelte';
 	import Alert from '$lib/components/Alert.svelte';
+	import CopyBadge from '$lib/components/CopyBadge.svelte';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
-
-	let copiedId = $state<string | null>(null);
-
-	async function copyCode(e: MouseEvent, code: string, id: string) {
-		e.preventDefault();
-		e.stopPropagation();
-		await navigator.clipboard.writeText(code);
-		copiedId = id;
-		setTimeout(() => (copiedId = null), 1500);
-	}
 </script>
 
 <PageContainer>
@@ -60,13 +51,10 @@
 				<a href="/groups/{group.id}" class="card bg-base-200 shadow transition hover:shadow-lg">
 					<div class="card-body flex-row items-center justify-between">
 						<h2 class="card-title">{group.name}</h2>
-						<button
-							class="flex items-center gap-1 font-mono text-sm opacity-70 hover:opacity-100"
-							onclick={(e) => copyCode(e, group.invite_code, group.id)}
-						>
-							<span class="badge badge-ghost font-mono">{group.invite_code}</span>
-							<span class="text-xs">{copiedId === group.id ? 'Copied!' : 'Copy'}</span>
-						</button>
+						<CopyBadge
+							text={group.invite_code}
+							onclick={(e) => { e.preventDefault(); e.stopPropagation(); }}
+						/>
 					</div>
 				</a>
 			{/each}

--- a/hubdle/src/routes/groups/[id]/+page.svelte
+++ b/hubdle/src/routes/groups/[id]/+page.svelte
@@ -5,16 +5,9 @@
 	import ScoreSubmitForm from '$lib/components/ScoreSubmitForm.svelte';
 	import Leaderboard from '$lib/components/Leaderboard.svelte';
 	import RecentSubmissions from '$lib/components/RecentSubmissions.svelte';
+	import CopyBadge from '$lib/components/CopyBadge.svelte';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
-
-	let copied = $state(false);
-
-	async function copyCode() {
-		await navigator.clipboard.writeText(data.group.invite_code);
-		copied = true;
-		setTimeout(() => (copied = false), 1500);
-	}
 </script>
 
 <PageContainer>
@@ -25,10 +18,7 @@
 		</div>
 		<div class="text-right">
 			<p class="text-xs opacity-50">Invite code</p>
-			<button class="flex items-center gap-2" onclick={copyCode}>
-				<span class="badge badge-ghost font-mono text-lg">{data.group.invite_code}</span>
-				<span class="text-xs opacity-70">{copied ? 'Copied!' : 'Copy'}</span>
-			</button>
+			<CopyBadge text={data.group.invite_code} size="lg" />
 		</div>
 	</div>
 


### PR DESCRIPTION
## Summary
- New `CopyBadge.svelte` component encapsulates clipboard copy + "Copied!" feedback
- Props: `text` (value to copy), `size` (`sm`/`lg`), optional `onclick` handler
- Replaced duplicated copy logic in groups list and group detail pages (~22 lines removed)

## Test plan
- [ ] Groups list: click copy button on a group card — shows "Copied!", doesn't navigate to group
- [ ] Group detail: click copy button next to invite code — shows "Copied!" with larger badge
- [ ] Feedback resets after 1.5s in both locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)