### PR TITLE
refactor: extract auth utility for username generation and profile upsert

### DIFF
--- a/hubdle/src/lib/auth.ts
+++ b/hubdle/src/lib/auth.ts
@@ -1,0 +1,13 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { User } from '@supabase/supabase-js';
+
+export function generateUsername(email: string | undefined, userId: string): string {
+	return email?.split('@')[0] ?? `user-${userId.slice(0, 8)}`;
+}
+
+export async function ensureProfile(supabase: SupabaseClient, user: User): Promise<void> {
+	const username = generateUsername(user.email, user.id);
+	await supabase
+		.from('profiles')
+		.upsert({ id: user.id, username }, { onConflict: 'id', ignoreDuplicates: true });
+}

--- a/hubdle/src/routes/auth/callback/+server.ts
+++ b/hubdle/src/routes/auth/callback/+server.ts
@@ -1,4 +1,5 @@
 import { redirect } from '@sveltejs/kit';
+import { ensureProfile } from '$lib/auth';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ url, locals }) => {
@@ -13,11 +14,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	} = await locals.supabase.auth.getUser();
 
 	if (user) {
-		const username = user.email?.split('@')[0] ?? `user-${user.id.slice(0, 8)}`;
-		await locals.supabase.from('profiles').upsert(
-			{ id: user.id, username },
-			{ onConflict: 'id' }
-		);
+		await ensureProfile(locals.supabase, user);
 	}
 
 	redirect(303, '/');

--- a/hubdle/src/routes/groups/+page.server.ts
+++ b/hubdle/src/routes/groups/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail, redirect } from '@sveltejs/kit';
+import { ensureProfile } from '$lib/auth';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -23,10 +24,7 @@ export const actions: Actions = {
 
 		if (!name?.trim()) return fail(400, { error: 'Group name is required.' });
 
-		const username = user.email?.split('@')[0] ?? `user-${user.id.slice(0, 8)}`;
-		await locals.supabase
-			.from('profiles')
-			.upsert({ id: user.id, username }, { onConflict: 'id', ignoreDuplicates: true });
+		await ensureProfile(locals.supabase, user);
 
 		const inviteCode = crypto.randomUUID().slice(0, 8);
 
@@ -56,11 +54,7 @@ export const actions: Actions = {
 
 		if (!code) return fail(400, { error: 'Invite code is required.' });
 
-		// Ensure profile exists
-		const username = user.email?.split('@')[0] ?? `user-${user.id.slice(0, 8)}`;
-		await locals.supabase
-			.from('profiles')
-			.upsert({ id: user.id, username }, { onConflict: 'id', ignoreDuplicates: true });
+		await ensureProfile(locals.supabase, user);
 
 		const { data: group } = await locals.supabase
 			.from('groups')

--- a/hubdle/src/routes/login/+page.svelte
+++ b/hubdle/src/routes/login/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { PageData } from './$types';
+	import { ensureProfile } from '$lib/auth';
 
 	let { data }: { data: PageData } = $props();
 
@@ -37,11 +38,7 @@
 				error = err.message;
 			} else {
 				if (signInData.user) {
-					const username = signInData.user.email?.split('@')[0] ?? `user-${signInData.user.id.slice(0, 8)}`;
-					await supabase.from('profiles').upsert(
-						{ id: signInData.user.id, username },
-						{ onConflict: 'id', ignoreDuplicates: true }
-					);
+					await ensureProfile(supabase, signInData.user);
 				}
 				window.location.href = '/';
 			}


### PR DESCRIPTION
## Summary
- New `lib/auth.ts` with `generateUsername()` and `ensureProfile()` functions
- Replaced 4 duplicated instances across `login/+page.svelte`, `groups/+page.server.ts` (2x), and `auth/callback/+server.ts`
- Fixes a bug in auth callback: was missing `ignoreDuplicates: true`, which would overwrite user-customized usernames on every OAuth login

## Test plan
- [ ] Sign in with email/password — profile created if new, existing username preserved
- [ ] Sign up + confirm email (OAuth callback) — profile created, username not overwritten on subsequent logins
- [ ] Create/join group — profile ensured without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)