### PR TITLE
refactor: use Alert component on login page

### DIFF
--- a/hubdle/src/routes/login/+page.svelte
+++ b/hubdle/src/routes/login/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { ensureProfile } from '$lib/auth';
+	import Alert from '$lib/components/Alert.svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -80,10 +81,10 @@
 				</label>
 
 				{#if error}
-					<p class="text-error text-sm">{error}</p>
+					<Alert type="error" message={error} />
 				{/if}
 				{#if signUpSuccess}
-					<p class="text-success text-sm">Check your email for a confirmation link.</p>
+					<Alert type="success" message="Check your email for a confirmation link." />
 				{/if}
 
 				<button class="btn btn-primary w-full" disabled={loading}>


### PR DESCRIPTION
## Summary
- Replace inline `<p class="text-error">` and `<p class="text-success">` with the shared `Alert` component
- Consistent error/success styling across all pages

## Test plan
- [ ] Sign in with wrong password — error alert renders styled consistently
- [ ] Sign up — success alert with confirmation link message renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)