### PR TITLE
fix: use static 'Profile' label in navbar instead of full email

### DIFF
--- a/hubdle/src/routes/+layout.svelte
+++ b/hubdle/src/routes/+layout.svelte
@@ -28,7 +28,7 @@
 		</div>
 		<div class="flex-none">
 			{#if data.user}
-				<NavLink href="/profile" label={data.user.email ?? 'Profile'} />
+				<NavLink href="/profile" label="Profile" />
 				<button class="btn btn-ghost btn-sm" onclick={handleLogout}>Log Out</button>
 			{:else}
 				<a href="/login" class="btn btn-primary btn-sm">Log In</a>


### PR DESCRIPTION
## Summary
- Changed profile NavLink label from `data.user.email` to static `"Profile"`
- Prevents navbar overflow with long email addresses
- Email is already displayed on the profile page itself

## Test plan
- [x] Navbar shows "Profile" link (not email) when logged in
- [x] Clicking "Profile" still navigates to `/profile` with active state

🤖 Generated with [Claude Code](https://claude.com/claude-code)