### PR TITLE
feat: add average score column to leaderboard

### DIFF
--- a/hubdle/src/lib/components/Leaderboard.svelte
+++ b/hubdle/src/lib/components/Leaderboard.svelte
@@ -112,7 +112,8 @@
 						<th>#</th>
 						<th>Player</th>
 						<th>Games</th>
-						<th>Total Score</th>
+						<th>Total</th>
+						<th>Avg</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -122,6 +123,7 @@
 							<td>{entry.username}</td>
 							<td>{entry.games}</td>
 							<td>{entry.total}</td>
+							<td>{(entry.total / entry.games).toFixed(1)}</td>
 						</tr>
 					{/each}
 				</tbody>


### PR DESCRIPTION
## Summary
- Added "Avg" column to the leaderboard table showing `(total / games).toFixed(1)`
- Renamed "Total Score" header to "Total" for compactness
- Gives fairer comparison when players have different numbers of games submitted

## Test plan
- [x] `npm run check` — 0 errors, 0 warnings
- [x] View leaderboard with scores — Avg column shows correct average per player
- [x] First-place row still highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)