### PR TITLE
feat: show member count on group cards

### DIFF
--- a/hubdle/src/routes/groups/+page.server.ts
+++ b/hubdle/src/routes/groups/+page.server.ts
@@ -6,12 +6,18 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const { user } = await locals.safeGetSession();
 	if (!user) redirect(303, '/login');
 
-	const { data: groups } = await locals.supabase
+	const { data: memberships } = await locals.supabase
 		.from('group_members')
-		.select('group_id, groups(id, name, invite_code, created_at)')
+		.select('group_id, groups(id, name, invite_code, created_at, group_members(count))')
 		.eq('user_id', user.id);
 
-	return { groups: groups?.map((gm) => gm.groups) ?? [] };
+	const groups = memberships?.map((gm) => {
+		const group = gm.groups;
+		const memberCount = group?.group_members?.[0]?.count ?? 0;
+		return { ...group, member_count: memberCount };
+	}) ?? [];
+
+	return { groups };
 };
 
 export const actions: Actions = {

--- a/hubdle/src/routes/groups/+page.svelte
+++ b/hubdle/src/routes/groups/+page.svelte
@@ -50,7 +50,10 @@
 			{#each data.groups as group}
 				<a href="/groups/{group.id}" class="card bg-base-200 shadow transition hover:shadow-lg">
 					<div class="card-body flex-row items-center justify-between">
-						<h2 class="card-title">{group.name}</h2>
+						<div>
+							<h2 class="card-title">{group.name}</h2>
+							<p class="text-sm opacity-50">{group.member_count} {group.member_count === 1 ? 'member' : 'members'}</p>
+						</div>
 						<CopyBadge
 							text={group.invite_code}
 							onclick={(e) => { e.preventDefault(); e.stopPropagation(); }}


### PR DESCRIPTION
## Summary
- Updated groups query to include member count via nested `group_members(count)`
- Display "X members" (or "1 member") below the group name on each card

## Test plan
- [x] `npm run check` — 0 errors, 0 warnings
- [ ] Visit `/groups` — each group card shows member count below the name
- [ ] Create a new group — card shows "1 member"
- [ ] After another user joins — count updates on next page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)