### PR TITLE
refactor: replace native confirm() with DaisyUI modal component

### DIFF
--- a/hubdle/src/lib/components/ConfirmModal.svelte
+++ b/hubdle/src/lib/components/ConfirmModal.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	let {
+		id,
+		title,
+		message,
+		triggerLabel,
+		triggerClass = 'btn-ghost',
+		confirmLabel = 'Confirm',
+		confirmClass = 'btn-error',
+		onConfirm
+	}: {
+		id: string;
+		title: string;
+		message: string;
+		triggerLabel: string;
+		triggerClass?: string;
+		confirmLabel?: string;
+		confirmClass?: string;
+		onConfirm: () => void;
+	} = $props();
+
+	function open() {
+		(document.getElementById(id) as HTMLDialogElement)?.showModal();
+	}
+
+	function close() {
+		(document.getElementById(id) as HTMLDialogElement)?.close();
+	}
+
+	function handleConfirm() {
+		close();
+		onConfirm();
+	}
+</script>
+
+<button type="button" class="btn {triggerClass}" onclick={open}>
+	{triggerLabel}
+</button>
+
+<dialog {id} class="modal">
+	<div class="modal-box">
+		<h3 class="text-lg font-bold">{title}</h3>
+		<p class="py-4">{message}</p>
+		<div class="modal-action">
+			<button class="btn btn-ghost" onclick={close}>Cancel</button>
+			<button class="btn {confirmClass}" onclick={handleConfirm}>{confirmLabel}</button>
+		</div>
+	</div>
+	<form method="dialog" class="modal-backdrop">
+		<button>close</button>
+	</form>
+</dialog>

--- a/hubdle/src/routes/groups/[id]/+page.svelte
+++ b/hubdle/src/routes/groups/[id]/+page.svelte
@@ -6,8 +6,12 @@
 	import Leaderboard from '$lib/components/Leaderboard.svelte';
 	import RecentSubmissions from '$lib/components/RecentSubmissions.svelte';
 	import CopyBadge from '$lib/components/CopyBadge.svelte';
+	import ConfirmModal from '$lib/components/ConfirmModal.svelte';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	let leaveForm = $state<HTMLFormElement>();
+	let deleteForm = $state<HTMLFormElement>();
 </script>
 
 <PageContainer>
@@ -36,31 +40,29 @@
 	</section>
 
 	<section class="mt-12 flex gap-3 border-t border-base-300 pt-6">
-		<form method="POST" action="?/leave" use:enhance>
-			<button
-				type="submit"
-				class="btn btn-ghost"
-				onclick={(e) => {
-					if (!confirm('Are you sure you want to leave this group?')) e.preventDefault();
-				}}
-			>
-				Leave Group
-			</button>
-		</form>
+		<form method="POST" action="?/leave" use:enhance bind:this={leaveForm} class="hidden"></form>
+		<ConfirmModal
+			id="leave-modal"
+			title="Leave Group"
+			message="Are you sure you want to leave this group?"
+			triggerLabel="Leave Group"
+			confirmLabel="Leave"
+			confirmClass="btn-ghost"
+			onConfirm={() => leaveForm?.requestSubmit()}
+		/>
 
 		{#if data.userId === data.group.created_by}
-			<form method="POST" action="?/delete" use:enhance>
-				<button
-					type="submit"
-					class="btn btn-error"
-					onclick={(e) => {
-						if (!confirm('Are you sure you want to delete this group? This cannot be undone.'))
-							e.preventDefault();
-					}}
-				>
-					Delete Group
-				</button>
-			</form>
+			<form method="POST" action="?/delete" use:enhance bind:this={deleteForm} class="hidden"></form>
+			<ConfirmModal
+				id="delete-modal"
+				title="Delete Group"
+				message="Are you sure you want to delete this group? This cannot be undone."
+				triggerLabel="Delete Group"
+				triggerClass="btn-error"
+				confirmLabel="Delete"
+				confirmClass="btn-error"
+				onConfirm={() => deleteForm?.requestSubmit()}
+			/>
 		{/if}
 	</section>
 </PageContainer>


### PR DESCRIPTION
## Summary
- New `ConfirmModal.svelte` component using DaisyUI's `<dialog>` modal
- Props: `id`, `title`, `message`, `triggerLabel`, `triggerClass`, `confirmLabel`, `confirmClass`, `onConfirm`
- Replaced both native `confirm()` dialogs on the group detail page (leave + delete)
- Modal can be dismissed by clicking backdrop, Cancel button, or Escape key
- Hidden forms with `bind:this` + `requestSubmit()` preserve SvelteKit `use:enhance` behavior

## Test plan
- [x] `npm run check` — 0 errors, 0 warnings
- [ ] Click "Leave Group" — styled modal appears with Cancel/Leave buttons
- [ ] Click "Delete Group" (as creator) — styled modal appears with Cancel/Delete buttons
- [ ] Click Cancel or backdrop — modal closes, no action taken
- [ ] Click Confirm — form submits, action executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)