### PR TITLE
feat: add manual score submission with per-game validation

### DIFF
--- a/hubdle/src/lib/components/ScoreSubmitForm.svelte
+++ b/hubdle/src/lib/components/ScoreSubmitForm.svelte
@@ -1,30 +1,86 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import Alert from './Alert.svelte';
+	import { GAME_RULES } from '$lib/game-rules';
 
-	let { form }: { form: { error?: string; success?: boolean } | null } = $props();
+	type Game = { id: string; name: string };
 
+	let {
+		form,
+		games
+	}: { form: { error?: string; success?: boolean } | null; games: Game[] } = $props();
+
+	let mode = $state<'paste' | 'manual'>('paste');
 	let rawText = $state('');
+	let gameId = $state('');
+	let score = $state('');
+	let gameDate = $state(new Date().toISOString().slice(0, 10));
+
+	let selectedRules = $derived(gameId ? GAME_RULES[gameId] : null);
 
 	$effect(() => {
-		if (form?.success) rawText = '';
+		if (form?.success) {
+			rawText = '';
+			score = '';
+		}
 	});
 </script>
 
 <section class="card mt-6 bg-base-200">
 	<div class="card-body">
-		<h2 class="card-title text-base">Submit Score</h2>
-		<form method="POST" action="?/submit" use:enhance class="flex flex-col gap-3">
-			<textarea
-				name="raw_text"
-				placeholder="Paste your share text here (e.g. Wordle 1,234 3/6)"
-				class="textarea textarea-bordered w-full"
-				rows="3"
-				required
-				bind:value={rawText}
-			></textarea>
-			<button class="btn btn-primary w-fit">Submit</button>
-		</form>
+		<div class="flex items-center justify-between">
+			<h2 class="card-title text-base">Submit Score</h2>
+			<button
+				class="btn btn-ghost btn-xs"
+				onclick={() => (mode = mode === 'paste' ? 'manual' : 'paste')}
+			>
+				{mode === 'paste' ? 'Enter manually' : 'Paste share text'}
+			</button>
+		</div>
+
+		{#if mode === 'paste'}
+			<form method="POST" action="?/submit" use:enhance class="flex flex-col gap-3">
+				<textarea
+					name="raw_text"
+					placeholder="Paste your share text here (e.g. Wordle 1,234 3/6)"
+					class="textarea textarea-bordered w-full"
+					rows="3"
+					required
+					bind:value={rawText}
+				></textarea>
+				<button class="btn btn-primary w-fit">Submit</button>
+			</form>
+		{:else}
+			<form method="POST" action="?/submitManual" use:enhance class="flex flex-col gap-3">
+				<select name="game_id" class="select select-bordered w-full" required bind:value={gameId}>
+					<option value="" disabled>Select a game</option>
+					{#each games as game}
+						<option value={game.id}>{game.name}</option>
+					{/each}
+				</select>
+				{#if selectedRules}
+					<div class="text-xs opacity-60">{selectedRules.hint}</div>
+				{/if}
+				<input
+					name="score"
+					type="number"
+					placeholder={selectedRules?.scoreLabel ?? 'Score'}
+					class="input input-bordered w-full"
+					required
+					min={selectedRules?.minScore}
+					max={selectedRules?.maxScore}
+					bind:value={score}
+				/>
+				<input
+					name="game_date"
+					type="date"
+					class="input input-bordered w-full"
+					required
+					bind:value={gameDate}
+				/>
+				<button class="btn btn-primary w-fit">Submit</button>
+			</form>
+		{/if}
 
 		{#if form?.error}
 			<Alert type="error" message={form.error} />

--- a/hubdle/src/lib/game-rules.ts
+++ b/hubdle/src/lib/game-rules.ts
@@ -1,0 +1,43 @@
+export type GameRules = {
+	minScore: number;
+	maxScore: number;
+	scoreLabel: string;
+	hint: string;
+};
+
+export const GAME_RULES: Record<string, GameRules> = {
+	wordle: {
+		minScore: 1,
+		maxScore: 7,
+		scoreLabel: 'Guesses (1–6, or 7 for X)',
+		hint: 'Number of guesses to solve. Enter 7 if you failed (X/6).'
+	},
+	bandle: {
+		minScore: 1,
+		maxScore: 7,
+		scoreLabel: 'Guesses (1–6, or 7 for X)',
+		hint: 'Number of guesses to solve. Enter 7 if you failed (X/6).'
+	},
+	connections: {
+		minScore: 0,
+		maxScore: 4,
+		scoreLabel: 'Mistakes (0–4)',
+		hint: 'Number of incorrect guesses before solving.'
+	},
+	contexto: {
+		minScore: 1,
+		maxScore: 500,
+		scoreLabel: 'Guesses (1–500)',
+		hint: 'Total number of guesses to find the secret word.'
+	}
+};
+
+export function validateScore(gameId: string, score: number): string | null {
+	const rules = GAME_RULES[gameId];
+	if (!rules) return null;
+	if (!Number.isInteger(score)) return 'Score must be a whole number.';
+	if (score < rules.minScore || score > rules.maxScore) {
+		return `Score for this game must be between ${rules.minScore} and ${rules.maxScore}.`;
+	}
+	return null;
+}

--- a/hubdle/src/routes/groups/[id]/+page.server.ts
+++ b/hubdle/src/routes/groups/[id]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error, fail, redirect } from '@sveltejs/kit';
 import { parseShareText } from '$lib/parsers';
+import { validateScore } from '$lib/game-rules';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
@@ -43,6 +44,9 @@ export const actions: Actions = {
 		const parsed = parseShareText(rawText);
 		if (!parsed) return fail(400, { error: 'Could not parse that share text. Supported games: Wordle, Bandle, Connections, Contexto.' });
 
+		const scoreError = validateScore(parsed.gameId, parsed.score);
+		if (scoreError) return fail(400, { error: scoreError });
+
 		const { error: insertError } = await locals.supabase.from('submissions').insert({
 			user_id: user.id,
 			group_id: params.id,
@@ -55,6 +59,41 @@ export const actions: Actions = {
 		if (insertError) {
 			if (insertError.code === '23505')
 				return fail(409, { error: 'You already submitted a score for this game today.' });
+			return fail(500, { error: `Failed to submit: ${insertError.message}` });
+		}
+
+		return { success: true };
+	},
+
+	submitManual: async ({ request, params, locals }) => {
+		const { user } = await locals.safeGetSession();
+		if (!user) redirect(303, '/login');
+
+		const formData = await request.formData();
+		const gameId = (formData.get('game_id') as string)?.trim();
+		const scoreStr = (formData.get('score') as string)?.trim();
+		const gameDate = (formData.get('game_date') as string)?.trim();
+
+		if (!gameId || !scoreStr || !gameDate) return fail(400, { error: 'All fields are required.' });
+
+		const score = parseInt(scoreStr, 10);
+		if (isNaN(score)) return fail(400, { error: 'Score must be a number.' });
+
+		const scoreError = validateScore(gameId, score);
+		if (scoreError) return fail(400, { error: scoreError });
+
+		const { error: insertError } = await locals.supabase.from('submissions').insert({
+			user_id: user.id,
+			group_id: params.id,
+			game_id: gameId,
+			score,
+			raw_text: `Manual: ${gameId} ${score}`,
+			game_date: gameDate
+		});
+
+		if (insertError) {
+			if (insertError.code === '23505')
+				return fail(409, { error: 'You already submitted a score for this game on that date.' });
 			return fail(500, { error: `Failed to submit: ${insertError.message}` });
 		}
 

--- a/hubdle/src/routes/groups/[id]/+page.svelte
+++ b/hubdle/src/routes/groups/[id]/+page.svelte
@@ -26,7 +26,7 @@
 		</div>
 	</div>
 
-	<ScoreSubmitForm {form} />
+	<ScoreSubmitForm {form} games={data.games} />
 	<Leaderboard games={data.games} submissions={data.submissions} members={data.members} />
 	<RecentSubmissions submissions={data.submissions} members={data.members} />
 


### PR DESCRIPTION
## Summary
- Add a "Enter manually" toggle to the score submit form, allowing users to select a game, enter a score, and pick a date instead of pasting share text
- Add shared game rules config (`$lib/game-rules.ts`) defining valid score bounds and scoring hints per game (Wordle 1–7, Bandle 1–7, Connections 0–4, Contexto 1–500)
- Validate scores against game bounds on both client side (HTML min/max attributes) and server side (both paste and manual actions)
- Show contextual hint text when a game is selected (e.g. "Number of guesses to solve. Enter 7 if you failed (X/6).")

## Test plan
- [ ] Open a group page and verify the "Enter manually" toggle appears next to "Submit Score"
- [ ] Switch to manual mode, select each game, and verify the hint text and placeholder update correctly
- [ ] Submit a valid manual score and verify it appears on the leaderboard
- [ ] Try submitting an out-of-range score (e.g. Wordle with 9) and verify it is rejected
- [ ] Verify paste mode still works as before
- [ ] Try submitting a duplicate manual score for the same game/date and verify the conflict error shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)