### PR TITLE
refactor: use const enum for submit mode in ScoreSubmitForm

### DIFF
--- a/hubdle/src/lib/components/ScoreSubmitForm.svelte
+++ b/hubdle/src/lib/components/ScoreSubmitForm.svelte
@@ -10,7 +10,10 @@
 		games
 	}: { form: { error?: string; success?: boolean } | null; games: Game[] } = $props();
 
-	let mode = $state<'paste' | 'manual'>('paste');
+	const SubmitMode = { Paste: 'paste', Manual: 'manual' } as const;
+	type SubmitMode = (typeof SubmitMode)[keyof typeof SubmitMode];
+
+	let mode = $state<SubmitMode>(SubmitMode.Paste);
 	let rawText = $state('');
 	let gameId = $state('');
 	let score = $state('');
@@ -32,13 +35,13 @@
 			<h2 class="card-title text-base">Submit Score</h2>
 			<button
 				class="btn btn-ghost btn-xs"
-				onclick={() => (mode = mode === 'paste' ? 'manual' : 'paste')}
+				onclick={() => (mode = mode === SubmitMode.Paste ? SubmitMode.Manual : SubmitMode.Paste)}
 			>
-				{mode === 'paste' ? 'Enter manually' : 'Paste share text'}
+				{mode === SubmitMode.Paste ? 'Enter manually' : 'Paste share text'}
 			</button>
 		</div>
 
-		{#if mode === 'paste'}
+		{#if mode === SubmitMode.Paste}
 			<form method="POST" action="?/submit" use:enhance class="flex flex-col gap-3">
 				<textarea
 					name="raw_text"


### PR DESCRIPTION
## Summary
- Replace raw `'paste'`/`'manual'` string literals with a `SubmitMode` const object (`SubmitMode.Paste`, `SubmitMode.Manual`)
- Follows the same pattern used for `TimeFilter` and `GameFilter` in the Leaderboard component

## Test plan
- [ ] Verify paste/manual toggle still works on the group detail page
- [ ] Verify both submit modes submit scores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)