### PR TITLE
fix: default to manual entry and prevent future date submissions

### DIFF
--- a/hubdle/src/lib/components/ScoreSubmitForm.svelte
+++ b/hubdle/src/lib/components/ScoreSubmitForm.svelte
@@ -13,11 +13,12 @@
 	const SubmitMode = { Paste: 'paste', Manual: 'manual' } as const;
 	type SubmitMode = (typeof SubmitMode)[keyof typeof SubmitMode];
 
-	let mode = $state<SubmitMode>(SubmitMode.Paste);
+	let mode = $state<SubmitMode>(SubmitMode.Manual);
 	let rawText = $state('');
 	let gameId = $state('');
 	let score = $state('');
-	let gameDate = $state(new Date().toISOString().slice(0, 10));
+	const today = new Date().toISOString().slice(0, 10);
+	let gameDate = $state(today);
 
 	let selectedRules = $derived(gameId ? GAME_RULES[gameId] : null);
 
@@ -79,6 +80,7 @@
 					type="date"
 					class="input input-bordered w-full"
 					required
+					max={today}
 					bind:value={gameDate}
 				/>
 				<button class="btn btn-primary w-fit">Submit</button>

--- a/hubdle/src/routes/groups/[id]/+page.server.ts
+++ b/hubdle/src/routes/groups/[id]/+page.server.ts
@@ -47,6 +47,9 @@ export const actions: Actions = {
 		const scoreError = validateScore(parsed.gameId, parsed.score);
 		if (scoreError) return fail(400, { error: scoreError });
 
+		const today = new Date().toISOString().slice(0, 10);
+		if (parsed.gameDate > today) return fail(400, { error: 'Cannot submit a score for a future date.' });
+
 		const { error: insertError } = await locals.supabase.from('submissions').insert({
 			user_id: user.id,
 			group_id: params.id,
@@ -81,6 +84,9 @@ export const actions: Actions = {
 
 		const scoreError = validateScore(gameId, score);
 		if (scoreError) return fail(400, { error: scoreError });
+
+		const today = new Date().toISOString().slice(0, 10);
+		if (gameDate > today) return fail(400, { error: 'Cannot submit a score for a future date.' });
 
 		const { error: insertError } = await locals.supabase.from('submissions').insert({
 			user_id: user.id,


### PR DESCRIPTION
## Summary
- Default the score submit form to manual mode (more intuitive than paste mode)
- Prevent future date submissions: `max` attribute on date picker (client-side) and date validation on both `submit` and `submitManual` actions (server-side)

## Test plan
- [ ] Open a group page — verify the form defaults to manual entry with "Paste share text" toggle visible
- [ ] Verify the date picker does not allow selecting future dates
- [ ] Submit a score via paste with a future puzzle date (if possible) — verify server rejects it
- [ ] Submit a valid score in both modes — verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)