### PR TITLE
fix: unsubscribe from realtime before deleting group

### DIFF
--- a/hubdle/src/routes/groups/[id]/+page.svelte
+++ b/hubdle/src/routes/groups/[id]/+page.svelte
@@ -171,7 +171,7 @@
 					triggerClass="btn-error btn-outline btn-sm"
 					confirmLabel="Delete"
 					confirmClass="btn-error"
-					onConfirm={() => deleteForm?.requestSubmit()}
+					onConfirm={() => { unsubscribeRealtime(); deleteForm?.requestSubmit(); }}
 				/>
 			{/if}
 		</div>


### PR DESCRIPTION
## Summary
- Unsubscribe from the realtime channel before submitting the delete form
- Fixes a race condition where the cascade delete on `group_members` triggers `invalidateAll()` via the realtime subscription, re-running the load function for the now-deleted group and hitting a 404 before the redirect completes

## Test plan
- [ ] Delete a group as the owner — verify it redirects to /groups instead of showing "Page not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)