### PR TITLE
feat: add Scrandle game support

### DIFF
--- a/hubdle/src/lib/game-rules.ts
+++ b/hubdle/src/lib/game-rules.ts
@@ -29,6 +29,12 @@ export const GAME_RULES: Record<string, GameRules> = {
 		maxScore: 500,
 		scoreLabel: 'Guesses (1–500)',
 		hint: 'Total number of guesses to find the secret word.'
+	},
+	scrandle: {
+		minScore: 0,
+		maxScore: 10,
+		scoreLabel: 'Correct guesses (0–10)',
+		hint: 'Number of rounds where you picked the more popular food.'
 	}
 };
 

--- a/hubdle/src/lib/parsers.ts
+++ b/hubdle/src/lib/parsers.ts
@@ -5,7 +5,13 @@ type ParseResult = {
 } | null;
 
 export function parseShareText(text: string): ParseResult {
-	return parseWordle(text) ?? parseBandle(text) ?? parseConnections(text) ?? parseContexto(text);
+	return (
+		parseWordle(text) ??
+		parseBandle(text) ??
+		parseConnections(text) ??
+		parseContexto(text) ??
+		parseScrandle(text)
+	);
 }
 
 function parseWordle(text: string): ParseResult {
@@ -77,4 +83,15 @@ function parseContexto(text: string): ParseResult {
 	const gameDate = epoch.toISOString().slice(0, 10);
 
 	return { gameId: 'contexto', score, gameDate };
+}
+
+function parseScrandle(text: string): ParseResult {
+	// "🟩🟥🟩🟩🟩🟥🟥🟩🟩🟩 7/10 | 2026-03-24 | https://scrandle.com"
+	const match = text.match(/(\d{1,2})\/10\s*\|\s*(\d{4}-\d{2}-\d{2})\s*\|\s*https?:\/\/scrandle\.com/);
+	if (!match) return null;
+
+	const score = parseInt(match[1], 10);
+	const gameDate = match[2];
+
+	return { gameId: 'scrandle', score, gameDate };
 }

--- a/hubdle/supabase/migrations/00001_initial_schema.sql
+++ b/hubdle/supabase/migrations/00001_initial_schema.sql
@@ -120,10 +120,4 @@ create policy "Users can insert own submissions"
   on public.submissions for insert
   with check (auth.uid() = user_id);
 
--- ============================================
--- Seed data
--- ============================================
-
-insert into public.games (id, name, url, score_direction) values
-  ('wordle', 'Wordle', 'https://www.nytimes.com/games/wordle', 'asc'),
-  ('bandle', 'Bandle', 'https://bandle.app', 'asc');
+-- Game seed data is in 00005_add_games.sql

--- a/hubdle/supabase/migrations/00005_add_games.sql
+++ b/hubdle/supabase/migrations/00005_add_games.sql
@@ -1,0 +1,8 @@
+-- All game seed data in one place
+insert into public.games (id, name, url, score_direction) values
+  ('wordle', 'Wordle', 'https://www.nytimes.com/games/wordle', 'asc'),
+  ('bandle', 'Bandle', 'https://bandle.app', 'asc'),
+  ('connections', 'Connections', 'https://www.nytimes.com/games/connections', 'asc'),
+  ('contexto', 'Contexto', 'https://contexto.me', 'asc'),
+  ('scrandle', 'Scrandle', 'https://scrandle.com', 'desc')
+on conflict (id) do nothing;


### PR DESCRIPTION
## Summary
- Add share-text parser for Scrandle (`score/10 | date | url` format)
- Add game rules (score 0–10, higher is better)
- Consolidate all game seed data into a single migration (`00005_add_games.sql`), removing the inline seed from the initial schema

## Test plan
- [ ] Paste a Scrandle share text and verify it parses correctly
- [ ] Submit a manual Scrandle score and verify validation (0–10 range)
- [ ] Run migration on a fresh DB and verify all games are seeded
- [ ] Run migration on existing DB and verify `ON CONFLICT DO NOTHING` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)