### PR TITLE
fix: show "(left)" for departed members and fix rejoin RLS

### DIFF
--- a/hubdle/src/lib/components/Leaderboard.svelte
+++ b/hubdle/src/lib/components/Leaderboard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	type Game = { id: string; name: string; url: string; score_direction: string };
 	type Submission = { user_id: string; score: number; game_id: string; game_date: string };
-	type Member = { user_id: string; profiles: { username: string } | null };
+	type Member = { user_id: string; left_at: string | null; profiles: { username: string } | null };
 
 	const TimeFilter = {
 		All: 'all',
@@ -53,10 +53,10 @@
 			return true;
 		});
 
-		const scores = new Map<string, { username: string; total: number; games: number }>();
+		const scores = new Map<string, { username: string; left: boolean; total: number; games: number }>();
 		for (const member of members) {
 			if (member.profiles) {
-				scores.set(member.user_id, { username: member.profiles.username, total: 0, games: 0 });
+				scores.set(member.user_id, { username: member.profiles.username, left: member.left_at !== null, total: 0, games: 0 });
 			}
 		}
 
@@ -131,7 +131,7 @@
 					{#each filteredLeaderboard as entry, i}
 						<tr class={i === 0 ? 'bg-base-300 font-semibold' : ''}>
 							<td>{i + 1}</td>
-							<td>{entry.username}</td>
+							<td>{entry.username}{#if entry.left} <span class="opacity-40 text-xs">(left)</span>{/if}</td>
 							<td>{entry.games}</td>
 							<td>{entry.total}</td>
 							<td>{(entry.total / entry.games).toFixed(1)}</td>

--- a/hubdle/src/lib/components/RecentSubmissions.svelte
+++ b/hubdle/src/lib/components/RecentSubmissions.svelte
@@ -6,7 +6,7 @@
 		game_date: string;
 		games: { name: string } | null;
 	};
-	type Member = { user_id: string; profiles: { username: string } | null };
+	type Member = { user_id: string; left_at: string | null; profiles: { username: string } | null };
 
 	let { submissions, members }: { submissions: Submission[]; members: Member[] } = $props();
 </script>
@@ -31,7 +31,7 @@
 						{#each submissions as sub}
 							{@const member = members.find((m) => m.user_id === sub.user_id)}
 							<tr>
-								<td>{member?.profiles?.username ?? 'Unknown'}</td>
+								<td>{member?.profiles?.username ?? 'Unknown'}{#if member?.left_at} <span class="opacity-40 text-xs">(left)</span>{/if}</td>
 								<td>{sub.games?.name ?? sub.game_id}</td>
 								<td>{sub.score}</td>
 								<td>{sub.game_date}</td>

--- a/hubdle/supabase/migrations/00006_soft_delete_group_members.sql
+++ b/hubdle/supabase/migrations/00006_soft_delete_group_members.sql
@@ -23,3 +23,9 @@ CREATE POLICY "Members can update own membership"
   ON public.group_members FOR UPDATE
   USING (auth.uid() = user_id)
   WITH CHECK (auth.uid() = user_id);
+
+-- Allow users to see their own membership rows (including soft-deleted)
+-- so the rejoin UPDATE can find the row to clear left_at
+CREATE POLICY "Users can view own memberships"
+  ON public.group_members FOR SELECT
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- Leaderboard and Recent Submissions now show "(left)" next to departed members' names
- Add RLS SELECT policy allowing users to view their own `group_members` rows (including soft-deleted), which unblocks the rejoin UPDATE path

## Test plan
- [ ] Verify departed members show "(left)" on the leaderboard and recent submissions
- [ ] Leave a group and rejoin via invite code — should work without error
- [ ] Run the new `CREATE POLICY` statement on the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)