### PR TITLE
feat: replace email/password login with GitHub and Google OAuth

### DIFF
--- a/hubdle/src/routes/login/+page.svelte
+++ b/hubdle/src/routes/login/+page.svelte
@@ -1,109 +1,71 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { ensureProfile } from '$lib/auth';
 	import Alert from '$lib/components/Alert.svelte';
 
 	let { data }: { data: PageData } = $props();
 
-	let email = $state('');
-	let password = $state('');
-	let isSignUp = $state(false);
 	let loading = $state(false);
 	let error = $state('');
-	let signUpSuccess = $state(false);
 
-	async function handleSubmit() {
+	async function handleOAuth(provider: 'github' | 'google') {
 		loading = true;
 		error = '';
-		signUpSuccess = false;
 
-		const { supabase } = data;
+		const { error: err } = await data.supabase.auth.signInWithOAuth({
+			provider,
+			options: { redirectTo: `${window.location.origin}/auth/callback` }
+		});
 
-		if (isSignUp) {
-			const { error: err } = await supabase.auth.signUp({
-				email,
-				password,
-				options: { emailRedirectTo: `${window.location.origin}/auth/callback` }
-			});
-			if (err) {
-				error = err.message;
-			} else {
-				signUpSuccess = true;
-			}
-		} else {
-			const { error: err, data: signInData } = await supabase.auth.signInWithPassword({
-				email,
-				password
-			});
-			if (err) {
-				error = err.message;
-			} else {
-				if (signInData.user) {
-					await ensureProfile(supabase, signInData.user);
-				}
-				window.location.href = '/';
-			}
+		if (err) {
+			error = err.message;
+			loading = false;
 		}
-
-		loading = false;
 	}
 </script>
 
 <div class="flex h-full items-center justify-center">
 	<div class="card w-full max-w-sm bg-base-200 shadow-xl">
 		<div class="card-body">
-			<h2 class="card-title justify-center text-2xl">
-				{isSignUp ? 'Sign Up' : 'Log In'}
-			</h2>
+			<h2 class="card-title justify-center text-2xl">Log In</h2>
 
-			<form onsubmit={handleSubmit} class="mt-4 flex flex-col gap-4">
-				<label class="floating-label">
-					<span>Email</span>
-					<input
-						type="email"
-						placeholder="Email"
-						class="input input-bordered w-full"
-						bind:value={email}
-						required
-					/>
-				</label>
-
-				<label class="floating-label">
-					<span>Password</span>
-					<input
-						type="password"
-						placeholder="Password"
-						class="input input-bordered w-full"
-						bind:value={password}
-						required
-						minlength="6"
-					/>
-				</label>
-
+			<div class="mt-4 flex flex-col gap-3">
 				{#if error}
 					<Alert type="error" message={error} />
 				{/if}
-				{#if signUpSuccess}
-					<Alert type="success" message="Check your email for a confirmation link." />
-				{/if}
 
-				<button class="btn btn-primary w-full" disabled={loading}>
+				<button
+					class="btn btn-outline w-full"
+					disabled={loading}
+					onclick={() => handleOAuth('github')}
+				>
 					{#if loading}
 						<span class="loading loading-spinner loading-sm"></span>
 					{:else}
-						{isSignUp ? 'Sign Up' : 'Log In'}
+						<svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+							<path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
+						</svg>
+						Continue with GitHub
 					{/if}
 				</button>
-			</form>
 
-			<div class="divider"></div>
-
-			<p class="text-center text-sm">
-				{isSignUp ? 'Already have an account?' : "Don't have an account?"}
-				<button class="link link-primary" onclick={() => (isSignUp = !isSignUp)}>
-					{isSignUp ? 'Log In' : 'Sign Up'}
+				<button
+					class="btn btn-outline w-full"
+					disabled={loading}
+					onclick={() => handleOAuth('google')}
+				>
+					{#if loading}
+						<span class="loading loading-spinner loading-sm"></span>
+					{:else}
+						<svg class="h-5 w-5" viewBox="0 0 24 24">
+							<path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
+							<path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+							<path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+							<path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+						</svg>
+						Continue with Google
+					{/if}
 				</button>
-			</p>
+			</div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
## Summary
- Replace email/password sign-up/login form with GitHub and Google OAuth buttons
- Removes rate-limited email auth in favor of unlimited OAuth flows
- Existing `/auth/callback` route handles OAuth code exchange and profile creation

## Test plan
- [ ] Click "Continue with GitHub" and verify login works
- [ ] Click "Continue with Google" and verify login works
- [ ] Verify profile is created with username derived from email
- [ ] Verify redirect to home page after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)