### PR TITLE
feat: add game links to group detail page

### DIFF
--- a/hubdle/src/routes/groups/[id]/+page.svelte
+++ b/hubdle/src/routes/groups/[id]/+page.svelte
@@ -82,6 +82,20 @@
 		</div>
 	</div>
 
+	<section class="mt-6 flex flex-wrap gap-2">
+		{#each data.games as game}
+			{#if game.url}
+				<a href={game.url} target="_blank" rel="noopener noreferrer" class="btn btn-outline btn-sm gap-1">
+					{game.name}
+					<svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
+						<path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+						<path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+					</svg>
+				</a>
+			{/if}
+		{/each}
+	</section>
+
 	<ScoreSubmitForm {form} games={data.games} />
 	<Leaderboard games={data.games} submissions={data.submissions} members={data.allMembers} />
 	<RecentSubmissions submissions={data.submissions} members={data.allMembers} userId={data.userId} />


### PR DESCRIPTION
## Summary
- Adds a row of game link buttons on the group detail page, below the header and above the submit form
- Each game with a URL in the database gets an outlined button with an external-link icon that opens the game in a new tab

## Test plan
- [ ] Visit a group detail page and verify game link buttons appear
- [ ] Click a game link and confirm it opens the correct URL in a new tab
- [ ] Verify games without a URL don't render a button

🤖 Generated with [Claude Code](https://claude.com/claude-code)