### PR TITLE
feat: add mutual friends system

### DIFF
--- a/hubdle/src/lib/components/NavLink.svelte
+++ b/hubdle/src/lib/components/NavLink.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 
-	let { href, label }: { href: string; label: string } = $props();
+	let { href, label, badge = 0 }: { href: string; label: string; badge?: number } = $props();
 
 	let isActive = $derived($page.url.pathname.startsWith(href));
 </script>
@@ -10,7 +10,7 @@
 	{href}
 	class="nav-link relative px-1 py-0.5 text-sm transition-colors hover:opacity-100 {isActive ? 'font-semibold opacity-100' : 'opacity-70'}"
 >
-	{label}
+	{label}{#if badge > 0}<span class="badge badge-primary badge-xs ml-1">{badge}</span>{/if}
 	<span
 		class="absolute bottom-0 left-1/2 h-px -translate-x-1/2 bg-current opacity-50 transition-all duration-300 ease-out {isActive ? 'w-[88%]' : 'w-0'}"
 	></span>

--- a/hubdle/src/lib/types/database.ts
+++ b/hubdle/src/lib/types/database.ts
@@ -14,6 +14,48 @@ export type Database = {
   }
   public: {
     Tables: {
+      friendships: {
+        Row: {
+          addressee_id: string
+          created_at: string
+          id: string
+          requester_id: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          addressee_id: string
+          created_at?: string
+          id?: string
+          requester_id: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          addressee_id?: string
+          created_at?: string
+          id?: string
+          requester_id?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "friendships_addressee_id_fkey"
+            columns: ["addressee_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "friendships_requester_id_fkey"
+            columns: ["requester_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       games: {
         Row: {
           id: string
@@ -184,6 +226,7 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      is_friend: { Args: { other_user_id: string }; Returns: boolean }
       is_group_member: { Args: { gid: string }; Returns: boolean }
     }
     Enums: {

--- a/hubdle/src/routes/+layout.server.ts
+++ b/hubdle/src/routes/+layout.server.ts
@@ -5,6 +5,7 @@ export const load: LayoutServerLoad = async ({ locals, cookies }) => {
 
 	let avatarUrl: string | null = null;
 	let username: string | null = null;
+	let friendRequestCount = 0;
 	if (user) {
 		const { data: profile } = await locals.supabase
 			.from('profiles')
@@ -13,7 +14,14 @@ export const load: LayoutServerLoad = async ({ locals, cookies }) => {
 			.single();
 		avatarUrl = profile?.avatar_url ?? null;
 		username = profile?.username ?? null;
+
+		const { count } = await locals.supabase
+			.from('friendships')
+			.select('id', { count: 'exact', head: true })
+			.eq('addressee_id', user.id)
+			.eq('status', 'pending');
+		friendRequestCount = count ?? 0;
 	}
 
-	return { user, avatarUrl, username, cookies: cookies.getAll() };
+	return { user, avatarUrl, username, friendRequestCount, cookies: cookies.getAll() };
 };

--- a/hubdle/src/routes/+layout.svelte
+++ b/hubdle/src/routes/+layout.svelte
@@ -54,6 +54,7 @@
 			{#if data.user}
 				<div class="hidden items-center gap-4 sm:flex">
 					<NavLink href="/groups" label="Groups" />
+					<NavLink href="/friends" label="Friends" badge={data.friendRequestCount} />
 				</div>
 			{/if}
 		</div>
@@ -95,6 +96,7 @@
 		<div class="border-b border-base-300 bg-base-200 px-4 py-3 sm:hidden">
 			<div class="flex flex-col gap-3">
 				<a href="/groups" class="text-sm" onclick={() => (menuOpen = false)}>Groups</a>
+				<a href="/friends" class="text-sm" onclick={() => (menuOpen = false)}>Friends{#if data.friendRequestCount > 0}<span class="badge badge-primary badge-xs ml-1">{data.friendRequestCount}</span>{/if}</a>
 				<a href="/users/{data.username ?? ''}" class="text-sm" onclick={() => (menuOpen = false)}>Profile</a>
 				<button class="text-left text-sm opacity-70" onclick={handleLogout}>Log Out</button>
 			</div>

--- a/hubdle/src/routes/+layout.ts
+++ b/hubdle/src/routes/+layout.ts
@@ -13,5 +13,5 @@ export const load: LayoutLoad = async ({ data, fetch }) => {
 				cookies: { getAll: () => data.cookies }
 			});
 
-	return { supabase, user: data.user, avatarUrl: data.avatarUrl, username: data.username };
+	return { supabase, user: data.user, avatarUrl: data.avatarUrl, username: data.username, friendRequestCount: data.friendRequestCount };
 };

--- a/hubdle/src/routes/friends/+page.server.ts
+++ b/hubdle/src/routes/friends/+page.server.ts
@@ -1,0 +1,127 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { ensureProfile } from '$lib/auth';
+import type { Actions, PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	const { user } = await locals.safeGetSession();
+	if (!user) redirect(303, '/login');
+
+	// Friends where current user is requester
+	const { data: asRequester } = await locals.supabase
+		.from('friendships')
+		.select('id, status, created_at, addressee:profiles!friendships_addressee_id_fkey(id, username, avatar_url)')
+		.eq('requester_id', user.id);
+
+	// Friends where current user is addressee
+	const { data: asAddressee } = await locals.supabase
+		.from('friendships')
+		.select('id, status, created_at, requester:profiles!friendships_requester_id_fkey(id, username, avatar_url)')
+		.eq('addressee_id', user.id);
+
+	const friends: { friendshipId: string; userId: string; username: string; avatarUrl: string | null }[] = [];
+	const outgoingRequests: typeof friends = [];
+	const incomingRequests: { friendshipId: string; userId: string; username: string; avatarUrl: string | null }[] = [];
+
+	for (const row of asRequester ?? []) {
+		const profile = row.addressee as unknown as { id: string; username: string; avatar_url: string | null } | null;
+		if (!profile) continue;
+		const entry = { friendshipId: row.id, userId: profile.id, username: profile.username, avatarUrl: profile.avatar_url };
+		if (row.status === 'accepted') friends.push(entry);
+		else outgoingRequests.push(entry);
+	}
+
+	for (const row of asAddressee ?? []) {
+		const profile = row.requester as unknown as { id: string; username: string; avatar_url: string | null } | null;
+		if (!profile) continue;
+		const entry = { friendshipId: row.id, userId: profile.id, username: profile.username, avatarUrl: profile.avatar_url };
+		if (row.status === 'accepted') friends.push(entry);
+		else incomingRequests.push(entry);
+	}
+
+	return { friends, incomingRequests, outgoingRequests, userId: user.id };
+};
+
+export const actions: Actions = {
+	sendRequest: async ({ request, locals }) => {
+		const { user } = await locals.safeGetSession();
+		if (!user) redirect(303, '/login');
+
+		const formData = await request.formData();
+		const addresseeId = (formData.get('addressee_id') as string)?.trim();
+
+		if (!addresseeId) return fail(400, { error: 'User ID is required.' });
+		if (addresseeId === user.id) return fail(400, { error: 'You cannot add yourself.' });
+
+		await ensureProfile(locals.supabase, user);
+
+		const { error: insertError } = await locals.supabase
+			.from('friendships')
+			.insert({ requester_id: user.id, addressee_id: addresseeId });
+
+		if (insertError) {
+			if (insertError.code === '23505') return fail(409, { error: 'Friend request already exists.' });
+			return fail(500, { error: `Failed to send request: ${insertError.message}` });
+		}
+
+		return { success: true };
+	},
+
+	acceptRequest: async ({ request, locals }) => {
+		const { user } = await locals.safeGetSession();
+		if (!user) redirect(303, '/login');
+
+		const formData = await request.formData();
+		const friendshipId = (formData.get('friendship_id') as string)?.trim();
+
+		if (!friendshipId) return fail(400, { error: 'Friendship ID is required.' });
+
+		const { error: updateError } = await locals.supabase
+			.from('friendships')
+			.update({ status: 'accepted', updated_at: new Date().toISOString() })
+			.eq('id', friendshipId)
+			.eq('addressee_id', user.id)
+			.eq('status', 'pending');
+
+		if (updateError) return fail(500, { error: `Failed to accept request: ${updateError.message}` });
+
+		return { success: true };
+	},
+
+	declineRequest: async ({ request, locals }) => {
+		const { user } = await locals.safeGetSession();
+		if (!user) redirect(303, '/login');
+
+		const formData = await request.formData();
+		const friendshipId = (formData.get('friendship_id') as string)?.trim();
+
+		if (!friendshipId) return fail(400, { error: 'Friendship ID is required.' });
+
+		const { error: deleteError } = await locals.supabase
+			.from('friendships')
+			.delete()
+			.eq('id', friendshipId);
+
+		if (deleteError) return fail(500, { error: `Failed to decline request: ${deleteError.message}` });
+
+		return { success: true };
+	},
+
+	removeFriend: async ({ request, locals }) => {
+		const { user } = await locals.safeGetSession();
+		if (!user) redirect(303, '/login');
+
+		const formData = await request.formData();
+		const friendshipId = (formData.get('friendship_id') as string)?.trim();
+
+		if (!friendshipId) return fail(400, { error: 'Friendship ID is required.' });
+
+		const { error: deleteError } = await locals.supabase
+			.from('friendships')
+			.delete()
+			.eq('id', friendshipId);
+
+		if (deleteError) return fail(500, { error: `Failed to remove friend: ${deleteError.message}` });
+
+		return { success: true };
+	}
+};

--- a/hubdle/src/routes/friends/+page.svelte
+++ b/hubdle/src/routes/friends/+page.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { onDestroy } from 'svelte';
+	import type { ActionData, PageData } from './$types';
+	import PageContainer from '$lib/components/PageContainer.svelte';
+	import Alert from '$lib/components/Alert.svelte';
+	import ConfirmModal from '$lib/components/ConfirmModal.svelte';
+
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	// Live search state
+	let searchQuery = $state('');
+	let searchResults = $state<{ id: string; username: string; avatarUrl: string | null; friendship: { friendshipId: string; status: string; direction: 'outgoing' | 'incoming' } | null }[]>([]);
+	let searched = $state(false);
+	let debounceTimer: ReturnType<typeof setTimeout>;
+
+	function handleSearchInput() {
+		clearTimeout(debounceTimer);
+		const query = searchQuery.trim();
+		if (query.length < 2) {
+			searchResults = [];
+			searched = false;
+			return;
+		}
+		debounceTimer = setTimeout(() => runSearch(query), 300);
+	}
+
+	async function runSearch(query: string) {
+		const userId = data.userId;
+
+		const { data: profiles } = await data.supabase
+			.from('profiles')
+			.select('id, username, avatar_url')
+			.neq('id', userId)
+			.ilike('username', `%${query}%`)
+			.limit(10);
+
+		if (!profiles || profiles.length === 0) {
+			searchResults = [];
+			searched = true;
+			return;
+		}
+
+		const profileIds = profiles.map((p) => p.id);
+		const { data: existingFriendships } = await data.supabase
+			.from('friendships')
+			.select('id, requester_id, addressee_id, status')
+			.or(
+				profileIds
+					.map((id) => `and(requester_id.eq.${userId},addressee_id.eq.${id}),and(requester_id.eq.${id},addressee_id.eq.${userId})`)
+					.join(',')
+			);
+
+		const friendshipMap = new Map<string, { friendshipId: string; status: string; direction: 'outgoing' | 'incoming' }>();
+		for (const f of existingFriendships ?? []) {
+			const otherId = f.requester_id === userId ? f.addressee_id : f.requester_id;
+			friendshipMap.set(otherId, {
+				friendshipId: f.id,
+				status: f.status,
+				direction: f.requester_id === userId ? 'outgoing' : 'incoming'
+			});
+		}
+
+		searchResults = profiles.map((p) => ({
+			id: p.id,
+			username: p.username,
+			avatarUrl: p.avatar_url,
+			friendship: friendshipMap.get(p.id) ?? null
+		}));
+		searched = true;
+	}
+
+	onDestroy(() => clearTimeout(debounceTimer));
+</script>
+
+<PageContainer>
+	<h1 class="text-2xl font-bold">Friends</h1>
+
+	{#if form?.error}
+		<Alert type="error" message={form.error} />
+	{/if}
+	{#if form?.success}
+		<Alert type="success" message="Done!" />
+	{/if}
+
+	<!-- Search -->
+	<section class="card mt-6 bg-base-200">
+		<div class="card-body gap-3">
+			<h2 class="card-title text-sm">Find friends</h2>
+			<input
+				type="text"
+				placeholder="Search by username"
+				bind:value={searchQuery}
+				oninput={handleSearchInput}
+				class="input input-bordered w-full"
+			/>
+
+			{#if searched && searchResults.length === 0}
+				<p class="text-sm opacity-60">No users found for "{searchQuery}".</p>
+			{:else if searchResults.length > 0}
+				<div class="mt-2 grid gap-2">
+					{#each searchResults as result}
+						<div class="flex items-center justify-between rounded-lg bg-base-300 px-4 py-2">
+							<a href="/users/{result.username}" class="font-medium hover:underline">{result.username}</a>
+							{#if result.friendship?.status === 'accepted'}
+								<span class="badge badge-success badge-sm">Friends</span>
+							{:else if result.friendship?.status === 'pending' && result.friendship.direction === 'outgoing'}
+								<span class="badge badge-sm">Pending</span>
+							{:else if result.friendship?.status === 'pending' && result.friendship.direction === 'incoming'}
+								<form method="POST" action="?/acceptRequest" use:enhance>
+									<input type="hidden" name="friendship_id" value={result.friendship.friendshipId} />
+									<button class="btn btn-primary btn-sm">Accept</button>
+								</form>
+							{:else}
+								<form method="POST" action="?/sendRequest" use:enhance>
+									<input type="hidden" name="addressee_id" value={result.id} />
+									<button class="btn btn-primary btn-outline btn-sm">Add Friend</button>
+								</form>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</section>
+
+	<!-- Incoming Requests -->
+	{#if data.incomingRequests.length > 0}
+		<section class="card mt-6 border border-base-300">
+			<div class="card-body">
+				<h2 class="card-title text-base">
+					Friend Requests
+					<span class="badge badge-primary badge-sm">{data.incomingRequests.length}</span>
+				</h2>
+				<div class="grid gap-2">
+					{#each data.incomingRequests as request}
+						<div class="flex items-center justify-between rounded-lg bg-base-200 px-4 py-2">
+							<a href="/users/{request.username}" class="font-medium hover:underline">{request.username}</a>
+							<div class="flex gap-2">
+								<form method="POST" action="?/acceptRequest" use:enhance>
+									<input type="hidden" name="friendship_id" value={request.friendshipId} />
+									<button class="btn btn-primary btn-sm">Accept</button>
+								</form>
+								<form method="POST" action="?/declineRequest" use:enhance>
+									<input type="hidden" name="friendship_id" value={request.friendshipId} />
+									<button class="btn btn-ghost btn-sm">Decline</button>
+								</form>
+							</div>
+						</div>
+					{/each}
+				</div>
+			</div>
+		</section>
+	{/if}
+
+	<!-- Outgoing Requests -->
+	{#if data.outgoingRequests.length > 0}
+		<section class="card mt-6 border border-base-300">
+			<div class="card-body">
+				<h2 class="card-title text-base">Sent Requests</h2>
+				<div class="grid gap-2">
+					{#each data.outgoingRequests as request}
+						<div class="flex items-center justify-between rounded-lg bg-base-200 px-4 py-2">
+							<a href="/users/{request.username}" class="font-medium hover:underline">{request.username}</a>
+							<form method="POST" action="?/declineRequest" use:enhance>
+								<input type="hidden" name="friendship_id" value={request.friendshipId} />
+								<button class="btn btn-ghost btn-sm">Cancel</button>
+							</form>
+						</div>
+					{/each}
+				</div>
+			</div>
+		</section>
+	{/if}
+
+	<!-- Friend List -->
+	<section class="card mt-6 border border-base-300">
+		<div class="card-body">
+			<h2 class="card-title text-base">
+				Your Friends
+				<span class="badge badge-sm">{data.friends.length}</span>
+			</h2>
+
+			{#if data.friends.length === 0}
+				<div class="flex flex-col items-center gap-3 py-6 text-center opacity-60">
+					<p class="text-4xl">👋</p>
+					<p class="font-medium">No friends yet</p>
+					<p class="text-sm">Search for users above to get started.</p>
+				</div>
+			{:else}
+				<div class="grid gap-2">
+					{#each data.friends as friend}
+						{@const formId = `remove-form-${friend.friendshipId}`}
+						<div class="flex items-center justify-between rounded-lg bg-base-200 px-4 py-2">
+							<a href="/users/{friend.username}" class="font-medium hover:underline">{friend.username}</a>
+							<form id={formId} method="POST" action="?/removeFriend" use:enhance class="hidden">
+								<input type="hidden" name="friendship_id" value={friend.friendshipId} />
+							</form>
+							<ConfirmModal
+								id="remove-{friend.friendshipId}"
+								title="Remove Friend"
+								message="Are you sure you want to remove {friend.username} as a friend?"
+								triggerLabel="Remove"
+								triggerClass="btn-error btn-outline btn-sm"
+								confirmLabel="Remove"
+								confirmClass="btn-error"
+								onConfirm={() => { (document.getElementById(formId) as HTMLFormElement)?.requestSubmit(); }}
+							/>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</section>
+</PageContainer>

--- a/hubdle/src/routes/groups/[id]/+page.server.ts
+++ b/hubdle/src/routes/groups/[id]/+page.server.ts
@@ -30,7 +30,27 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 
 	const { data: games } = await locals.supabase.from('games').select('id, name, url, score_direction');
 
-	return { group, members, allMembers: allMembers ?? [], submissions: submissions ?? [], games: games ?? [], userId: user.id };
+	// Fetch friends who can be invited (not already active members)
+	const { data: friendsAsRequester } = await locals.supabase
+		.from('friendships')
+		.select('addressee:profiles!friendships_addressee_id_fkey(id, username)')
+		.eq('requester_id', user.id)
+		.eq('status', 'accepted');
+
+	const { data: friendsAsAddressee } = await locals.supabase
+		.from('friendships')
+		.select('requester:profiles!friendships_requester_id_fkey(id, username)')
+		.eq('addressee_id', user.id)
+		.eq('status', 'accepted');
+
+	const memberIds = new Set(members.map((m) => m.user_id));
+	const allFriends = [
+		...(friendsAsRequester ?? []).map((f) => f.addressee as unknown as { id: string; username: string } | null),
+		...(friendsAsAddressee ?? []).map((f) => f.requester as unknown as { id: string; username: string } | null)
+	];
+	const invitableFriends = allFriends.filter((f): f is { id: string; username: string } => f != null && !memberIds.has(f.id));
+
+	return { group, members, allMembers: allMembers ?? [], submissions: submissions ?? [], games: games ?? [], userId: user.id, invitableFriends };
 };
 
 export const actions: Actions = {
@@ -269,6 +289,42 @@ export const actions: Actions = {
 		if (deleteError) return fail(500, { error: `Failed to delete group: ${deleteError.message}` });
 
 		redirect(303, '/groups');
+	},
+
+	inviteFriend: async ({ request, params, locals }) => {
+		const { user } = await locals.safeGetSession();
+		if (!user) redirect(303, '/login');
+
+		const formData = await request.formData();
+		const friendId = (formData.get('friend_id') as string)?.trim();
+
+		if (!friendId) return fail(400, { error: 'Please select a friend to invite.' });
+
+		const { error: insertError } = await locals.supabase
+			.from('group_members')
+			.insert({ group_id: params.id, user_id: friendId });
+
+		if (insertError) {
+			if (insertError.code === '23505') {
+				// Row exists — try to rejoin soft-deleted member
+				const { data: updated, error: updateError } = await locals.supabase
+					.from('group_members')
+					.update({ left_at: null, joined_at: new Date().toISOString() })
+					.eq('group_id', params.id)
+					.eq('user_id', friendId)
+					.not('left_at', 'is', null)
+					.select();
+
+				if (updateError) return fail(500, { error: 'Failed to invite friend.' });
+				if (!updated || updated.length === 0) {
+					return fail(409, { error: 'This user is already in the group.' });
+				}
+			} else {
+				return fail(500, { error: `Failed to invite friend: ${insertError.message}` });
+			}
+		}
+
+		return { success: true };
 	},
 
 	delete: async ({ params, locals }) => {

--- a/hubdle/src/routes/groups/[id]/+page.svelte
+++ b/hubdle/src/routes/groups/[id]/+page.svelte
@@ -119,6 +119,18 @@
 					</a>
 				{/each}
 			</div>
+
+			{#if data.invitableFriends.length > 0}
+				<form method="POST" action="?/inviteFriend" use:enhance class="mt-3 flex items-center gap-2">
+					<select name="friend_id" class="select select-bordered select-sm flex-1" required>
+						<option value="" disabled selected>Invite a friend...</option>
+						{#each data.invitableFriends as friend}
+							<option value={friend.id}>{friend.username}</option>
+						{/each}
+					</select>
+					<button class="btn btn-primary btn-sm">Invite</button>
+				</form>
+			{/if}
 		</div>
 	</section>
 

--- a/hubdle/src/routes/users/[username]/+page.server.ts
+++ b/hubdle/src/routes/users/[username]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error, fail, redirect } from '@sveltejs/kit';
 import { GAME_RULES, validateScore } from '$lib/game-rules';
+import { ensureProfile } from '$lib/auth';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
@@ -104,13 +105,33 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		gameDate: sub.game_date
 	}));
 
+	// Friendship status (only for other users when logged in)
+	let friendship: { id: string; status: string; direction: 'outgoing' | 'incoming' } | null = null;
+	if (user && !isOwnProfile) {
+		const { data: existing } = await locals.supabase
+			.from('friendships')
+			.select('id, requester_id, status')
+			.or(`and(requester_id.eq.${user.id},addressee_id.eq.${profile.id}),and(requester_id.eq.${profile.id},addressee_id.eq.${user.id})`)
+			.maybeSingle();
+
+		if (existing) {
+			friendship = {
+				id: existing.id,
+				status: existing.status,
+				direction: existing.requester_id === user.id ? 'outgoing' : 'incoming'
+			};
+		}
+	}
+
 	return {
 		profile: {
+			id: profile.id,
 			username: profile.username,
 			avatarUrl: profile.avatar_url,
 			createdAt: profile.created_at
 		},
 		isOwnProfile,
+		friendship,
 		stats: {
 			totalSubmissions: allSubs.length,
 			totalGroups: totalGroups ?? 0,
@@ -146,6 +167,51 @@ export const actions: Actions = {
 			.eq('user_id', user.id);
 
 		if (updateError) return fail(500, { error: `Failed to update: ${updateError.message}` });
+
+		return { success: true };
+	},
+
+	sendRequest: async ({ request, locals }) => {
+		const { user } = await locals.safeGetSession();
+		if (!user) redirect(303, '/login');
+
+		const formData = await request.formData();
+		const addresseeId = (formData.get('addressee_id') as string)?.trim();
+
+		if (!addresseeId) return fail(400, { error: 'User ID is required.' });
+		if (addresseeId === user.id) return fail(400, { error: 'You cannot add yourself.' });
+
+		await ensureProfile(locals.supabase, user);
+
+		const { error: insertError } = await locals.supabase
+			.from('friendships')
+			.insert({ requester_id: user.id, addressee_id: addresseeId });
+
+		if (insertError) {
+			if (insertError.code === '23505') return fail(409, { error: 'Friend request already exists.' });
+			return fail(500, { error: `Failed to send request: ${insertError.message}` });
+		}
+
+		return { success: true };
+	},
+
+	acceptRequest: async ({ request, locals }) => {
+		const { user } = await locals.safeGetSession();
+		if (!user) redirect(303, '/login');
+
+		const formData = await request.formData();
+		const friendshipId = (formData.get('friendship_id') as string)?.trim();
+
+		if (!friendshipId) return fail(400, { error: 'Friendship ID is required.' });
+
+		const { error: updateError } = await locals.supabase
+			.from('friendships')
+			.update({ status: 'accepted', updated_at: new Date().toISOString() })
+			.eq('id', friendshipId)
+			.eq('addressee_id', user.id)
+			.eq('status', 'pending');
+
+		if (updateError) return fail(500, { error: `Failed to accept request: ${updateError.message}` });
 
 		return { success: true };
 	},

--- a/hubdle/src/routes/users/[username]/+page.svelte
+++ b/hubdle/src/routes/users/[username]/+page.svelte
@@ -41,15 +41,36 @@
 </script>
 
 <PageContainer>
-	<div class="flex items-center gap-4">
-		<Avatar src={data.profile.avatarUrl} username={data.profile.username} size="lg" />
-		<div>
-			<h1 class="text-2xl font-bold">{data.profile.username}</h1>
-			<p class="text-sm opacity-50">Member since {memberSince}</p>
-			{#if data.isOwnProfile}
-				<a href="/profile" class="link text-sm opacity-70">Edit Profile</a>
-			{/if}
+	<div class="flex items-center justify-between gap-4">
+		<div class="flex items-center gap-4">
+			<Avatar src={data.profile.avatarUrl} username={data.profile.username} size="lg" />
+			<div>
+				<h1 class="text-2xl font-bold">{data.profile.username}</h1>
+				<p class="text-sm opacity-50">Member since {memberSince}</p>
+				{#if data.isOwnProfile}
+					<a href="/profile" class="link text-sm opacity-70">Edit Profile</a>
+				{/if}
+			</div>
 		</div>
+		{#if !data.isOwnProfile}
+			<div>
+				{#if data.friendship?.status === 'accepted'}
+					<span class="badge badge-success">Friends</span>
+				{:else if data.friendship?.status === 'pending' && data.friendship.direction === 'outgoing'}
+					<span class="badge">Request Pending</span>
+				{:else if data.friendship?.status === 'pending' && data.friendship.direction === 'incoming'}
+					<form method="POST" action="?/acceptRequest" use:enhance>
+						<input type="hidden" name="friendship_id" value={data.friendship.id} />
+						<button class="btn btn-primary btn-sm">Accept Friend Request</button>
+					</form>
+				{:else}
+					<form method="POST" action="?/sendRequest" use:enhance>
+						<input type="hidden" name="addressee_id" value={data.profile.id} />
+						<button class="btn btn-primary btn-outline btn-sm">Add Friend</button>
+					</form>
+				{/if}
+			</div>
+		{/if}
 	</div>
 
 	{#if form?.error}

--- a/hubdle/supabase/migrations/00009_friendships.sql
+++ b/hubdle/supabase/migrations/00009_friendships.sql
@@ -1,0 +1,75 @@
+-- ============================================
+-- Friendships table
+-- ============================================
+
+create table public.friendships (
+  id uuid primary key default gen_random_uuid(),
+  requester_id uuid not null references public.profiles(id) on delete cascade,
+  addressee_id uuid not null references public.profiles(id) on delete cascade,
+  status text not null default 'pending' check (status in ('pending', 'accepted')),
+  created_at timestamptz default now() not null,
+  updated_at timestamptz default now() not null,
+  check (requester_id != addressee_id)
+);
+
+-- Prevent duplicate friendship pairs regardless of direction
+create unique index friendships_unique_pair
+  on public.friendships (least(requester_id, addressee_id), greatest(requester_id, addressee_id));
+
+-- ============================================
+-- Helper function
+-- ============================================
+
+create or replace function public.is_friend(other_user_id uuid)
+returns boolean
+language sql
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1 from public.friendships
+    where status = 'accepted'
+      and (
+        (requester_id = auth.uid() and addressee_id = other_user_id)
+        or (requester_id = other_user_id and addressee_id = auth.uid())
+      )
+  );
+$$;
+
+-- ============================================
+-- Row Level Security
+-- ============================================
+
+alter table public.friendships enable row level security;
+
+-- Users can see friendships they are part of
+create policy "Users can view own friendships"
+  on public.friendships for select
+  using (auth.uid() = requester_id or auth.uid() = addressee_id);
+
+-- Users can send friend requests (they must be the requester, status must be pending)
+create policy "Users can send friend requests"
+  on public.friendships for insert
+  with check (auth.uid() = requester_id and status = 'pending');
+
+-- Addressee can accept a pending request (update status to accepted)
+create policy "Addressee can accept friend request"
+  on public.friendships for update
+  using (auth.uid() = addressee_id and status = 'pending')
+  with check (status = 'accepted');
+
+-- Either party can delete (unfriend or decline)
+create policy "Either party can delete friendship"
+  on public.friendships for delete
+  using (auth.uid() = requester_id or auth.uid() = addressee_id);
+
+-- ============================================
+-- Allow group members to invite friends
+-- ============================================
+
+create policy "Members can invite friends to groups"
+  on public.group_members for insert
+  with check (
+    public.is_group_member(group_id)
+    and public.is_friend(user_id)
+  );


### PR DESCRIPTION
## Summary
- Add `friendships` table (migration `00009`) with mutual request/accept flow, RLS policies, `is_friend()` helper, and unique pair index to prevent duplicates
- Add `/friends` page with live debounced username search, incoming/outgoing request management, and friend list with remove confirmation
- Add friend request count badge to navbar (desktop + mobile) via `NavLink` badge prop
- Add friend status (Add Friend / Pending / Accept / Friends) on user profile pages (`/users/[username]`)
- Add "Invite a friend" dropdown on group detail page — lets members directly add friends to groups (with soft-delete rejoin support)

## Test plan
- [ ] Apply migration `00009_friendships.sql` to Supabase
- [ ] Run `npm run db:types` to regenerate types
- [ ] Verify live search on `/friends` returns results as you type
- [ ] Send a friend request and verify it appears as "Pending" for sender, as incoming request for receiver
- [ ] Accept/decline requests and verify state updates
- [ ] Remove a friend and verify the confirmation modal works
- [ ] Check navbar badge shows pending request count and disappears when all are handled
- [ ] Visit another user's profile and verify Add Friend / Accept / Pending / Friends status displays correctly
- [ ] On a group page, verify the "Invite a friend" dropdown shows only friends not already in the group
- [ ] Invite a friend to a group and verify they appear as a member

🤖 Generated with [Claude Code](https://claude.com/claude-code)