### PR TITLE
chore: disable Vercel preview deployments

### DIFF
--- a/hubdle/vercel.json
+++ b/hubdle/vercel.json
@@ -1,0 +1,7 @@
+{
+	"git": {
+		"deploymentEnabled": {
+			"preview": false
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `vercel.json` to disable preview deployments for non-production branches
- Only the production branch (main) will trigger Vercel builds going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)