### PR TITLE
fix: page titles, error page, and duplicate username handling

### DIFF
--- a/hubdle/src/routes/+error.svelte
+++ b/hubdle/src/routes/+error.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import PageContainer from '$lib/components/PageContainer.svelte';
+</script>
+
+<svelte:head>
+	<title>{$page.status} - Hubdle</title>
+</svelte:head>
+
+<PageContainer>
+	<div class="flex h-full flex-col items-center justify-center py-24 text-center">
+		<p class="text-6xl font-bold opacity-20">{$page.status}</p>
+		<p class="mt-4 text-lg opacity-70">{$page.error?.message ?? 'Something went wrong.'}</p>
+		<a href="/" class="btn btn-primary btn-outline mt-6">Go Home</a>
+	</div>
+</PageContainer>

--- a/hubdle/src/routes/+page.svelte
+++ b/hubdle/src/routes/+page.svelte
@@ -1,3 +1,7 @@
+<svelte:head>
+	<title>Hubdle</title>
+</svelte:head>
+
 <div class="flex h-full flex-col items-center justify-center text-center">
 	<h1 class="text-4xl font-bold">Hubdle</h1>
 	<p class="mt-4 max-w-md opacity-70">

--- a/hubdle/src/routes/friends/+page.svelte
+++ b/hubdle/src/routes/friends/+page.svelte
@@ -88,6 +88,10 @@
 	}
 </script>
 
+<svelte:head>
+	<title>Friends - Hubdle</title>
+</svelte:head>
+
 <PageContainer>
 	<h1 class="text-2xl font-bold">Friends</h1>
 

--- a/hubdle/src/routes/groups/+page.svelte
+++ b/hubdle/src/routes/groups/+page.svelte
@@ -11,6 +11,10 @@
 	let joining = $state(false);
 </script>
 
+<svelte:head>
+	<title>Groups - Hubdle</title>
+</svelte:head>
+
 <PageContainer>
 	<h1 class="text-2xl font-bold">Your Groups</h1>
 

--- a/hubdle/src/routes/groups/[id]/+page.svelte
+++ b/hubdle/src/routes/groups/[id]/+page.svelte
@@ -74,6 +74,10 @@
 	}
 </script>
 
+<svelte:head>
+	<title>{data.group.name} - Hubdle</title>
+</svelte:head>
+
 <PageContainer>
 	<div>
 		<a href="/groups" class="link text-sm opacity-70">&larr; All Groups</a>

--- a/hubdle/src/routes/login/+page.svelte
+++ b/hubdle/src/routes/login/+page.svelte
@@ -23,6 +23,10 @@
 	}
 </script>
 
+<svelte:head>
+	<title>Log In - Hubdle</title>
+</svelte:head>
+
 <div class="flex h-full items-center justify-center">
 	<div class="card w-full max-w-sm bg-base-200 shadow-xl">
 		<div class="card-body">

--- a/hubdle/src/routes/profile/+page.server.ts
+++ b/hubdle/src/routes/profile/+page.server.ts
@@ -34,7 +34,10 @@ export const actions: Actions = {
 			.update({ username })
 			.eq('id', user.id);
 
-		if (error) return fail(500, { error: `Failed to update username: ${error.message}` });
+		if (error) {
+			if (error.code === '23505') return fail(409, { error: 'That username is already taken.' });
+			return fail(500, { error: `Failed to update username: ${error.message}` });
+		}
 
 		return { success: true };
 	},

--- a/hubdle/src/routes/profile/+page.svelte
+++ b/hubdle/src/routes/profile/+page.svelte
@@ -39,6 +39,10 @@
 
 </script>
 
+<svelte:head>
+	<title>Profile - Hubdle</title>
+</svelte:head>
+
 <PageContainer>
 	<div class="flex items-center justify-between">
 		<h1 class="text-2xl font-bold">Profile</h1>

--- a/hubdle/src/routes/users/[username]/+page.svelte
+++ b/hubdle/src/routes/users/[username]/+page.svelte
@@ -41,6 +41,10 @@
 	);
 </script>
 
+<svelte:head>
+	<title>{data.profile.username} - Hubdle</title>
+</svelte:head>
+
 <PageContainer>
 	<div class="flex items-center justify-between gap-4">
 		<div class="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- **Page titles**: Add `<title>` tags to all pages — landing ("Hubdle"), login ("Log In - Hubdle"), groups, group detail (shows group name), friends, profile, and user profile (shows username)
- **Branded error page**: New `+error.svelte` with centered status code, error message, and "Go Home" link (replaces SvelteKit's default unstyled 404/500 pages)
- **Duplicate username error**: Handle `23505` unique constraint on username update with a clear "That username is already taken" message instead of a generic 500

## Test plan
- [ ] Each page shows its title in the browser tab
- [ ] Navigate to `/nonexistent` — shows styled 404 page with "Go Home" link
- [ ] Navigate to `/users/nonexistent` — shows styled 404 "User not found"
- [ ] Try changing username to one that's already taken — shows "already taken" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)