### PR TITLE
fix: center login card when navbar is hidden

### DIFF
--- a/hubdle/src/routes/login/+page.svelte
+++ b/hubdle/src/routes/login/+page.svelte
@@ -27,7 +27,7 @@
 	<title>Log In - Hubdle</title>
 </svelte:head>
 
-<div class="flex h-full items-center justify-center">
+<div class="flex min-h-screen items-center justify-center">
 	<div class="card w-full max-w-sm bg-base-200 shadow-xl">
 		<div class="card-body">
 			<h2 class="card-title justify-center text-2xl">Log In</h2>


### PR DESCRIPTION
## Summary
Use `min-h-screen` instead of `h-full` on the login page container so the card centers relative to the viewport. The hidden navbar breaks the `h-full` chain from the grid layout.

## Test plan
- [ ] Login page card is vertically centered on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)