### PR TITLE
feat: replace GitHub OAuth with Microsoft

### DIFF
--- a/hubdle/src/lib/auth.ts
+++ b/hubdle/src/lib/auth.ts
@@ -1,8 +1,9 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { User } from '@supabase/supabase-js';
 
-export function generateUsername(email: string | undefined, userId: string): string {
-	return email?.split('@')[0] ?? `user-${userId.slice(0, 8)}`;
+export function generateUsername(user: User): string {
+	const email = user.email || user.user_metadata?.email;
+	return email?.split('@')[0] ?? `user-${user.id.slice(0, 8)}`;
 }
 
 export function getOAuthAvatarUrl(user: User): string | null {
@@ -10,7 +11,7 @@ export function getOAuthAvatarUrl(user: User): string | null {
 }
 
 export async function ensureProfile(supabase: SupabaseClient, user: User): Promise<void> {
-	const username = generateUsername(user.email, user.id);
+	const username = generateUsername(user);
 	const avatarUrl = getOAuthAvatarUrl(user);
 
 	await supabase

--- a/hubdle/src/routes/+layout.svelte
+++ b/hubdle/src/routes/+layout.svelte
@@ -59,8 +59,9 @@
 			<div class="h-full bg-primary {loadingDone ? 'loading-bar-done' : 'loading-bar'}"></div>
 		</div>
 	{/if}
-	<nav class="bg-base-200" class:hidden={$page.url.pathname.startsWith('/login')}>
-		<div class="navbar mx-auto max-w-4xl px-6">
+	<nav class="bg-base-200">
+		<div class="navbar mx-auto max-w-4xl px-6 {$page.url.pathname.startsWith('/login') ? 'justify-center' : ''}">
+			{#if !$page.url.pathname.startsWith('/login')}
 			<div class="flex flex-1 items-center gap-6">
 				<a href="/" class="flex items-center gap-2 text-xl font-bold">
 					<img src={favicon} alt="Hubdle" class="h-7 w-7" />
@@ -143,6 +144,12 @@
 					</div>
 				{/if}
 			</div>
+			{:else}
+			<a href="/" class="flex items-center gap-2 text-xl font-bold">
+				<img src={favicon} alt="Hubdle" class="h-7 w-7" />
+				Hubdle
+			</a>
+			{/if}
 		</div>
 	</nav>
 

--- a/hubdle/src/routes/login/+page.svelte
+++ b/hubdle/src/routes/login/+page.svelte
@@ -7,13 +7,16 @@
 	let loading = $state(false);
 	let error = $state('');
 
-	async function handleOAuth(provider: 'github' | 'google') {
+	async function handleOAuth(provider: 'azure' | 'google') {
 		loading = true;
 		error = '';
 
 		const { error: err } = await data.supabase.auth.signInWithOAuth({
 			provider,
-			options: { redirectTo: `${window.location.origin}/auth/callback` }
+			options: {
+				redirectTo: `${window.location.origin}/auth/callback`,
+				...(provider === 'azure' && { scopes: 'openid email profile' })
+			}
 		});
 
 		if (err) {
@@ -40,21 +43,6 @@
 				<button
 					class="btn btn-outline w-full"
 					disabled={loading}
-					onclick={() => handleOAuth('github')}
-				>
-					{#if loading}
-						<span class="loading loading-spinner loading-sm"></span>
-					{:else}
-						<svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
-							<path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
-						</svg>
-						Continue with GitHub
-					{/if}
-				</button>
-
-				<button
-					class="btn btn-outline w-full"
-					disabled={loading}
 					onclick={() => handleOAuth('google')}
 				>
 					{#if loading}
@@ -67,6 +55,24 @@
 							<path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
 						</svg>
 						Continue with Google
+					{/if}
+				</button>
+
+				<button
+					class="btn btn-outline w-full"
+					disabled={loading}
+					onclick={() => handleOAuth('azure')}
+				>
+					{#if loading}
+						<span class="loading loading-spinner loading-sm"></span>
+					{:else}
+						<svg class="h-5 w-5" viewBox="0 0 23 23" fill="none">
+							<rect width="11" height="11" fill="#F25022"/>
+							<rect x="12" width="11" height="11" fill="#7FBA00"/>
+							<rect y="12" width="11" height="11" fill="#00A4EF"/>
+							<rect x="12" y="12" width="11" height="11" fill="#FFB900"/>
+						</svg>
+						Continue with Microsoft
 					{/if}
 				</button>
 			</div>

--- a/hubdle/src/routes/profile/+page.server.ts
+++ b/hubdle/src/routes/profile/+page.server.ts
@@ -12,7 +12,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 		.single();
 
 	return {
-		email: user.email ?? '',
+		email: user.email || user.user_metadata?.email || '',
 		username: profile?.username ?? '',
 		avatarUrl: profile?.avatar_url ?? null
 	};


### PR DESCRIPTION
## Summary
- Replace GitHub OAuth login with Microsoft (Azure) OAuth provider
- Fix email and username extraction for Microsoft users (email is in `user_metadata` instead of top-level `user.email`)
- Show navbar on login page with centered Hubdle logo
- Reorder login buttons: Google first, Microsoft second

## Test plan
- [ ] Log in with Microsoft — verify email, username, and profile are created correctly
- [ ] Log in with Google — verify existing flow still works
- [ ] Verify login page shows navbar with centered logo
- [ ] Verify profile page shows correct email for Microsoft users

🤖 Generated with [Claude Code](https://claude.com/claude-code)