### PR TITLE
fix: parallelize sequential Supabase queries to reduce page load time

### DIFF
--- a/hubdle/src/routes/+layout.server.ts
+++ b/hubdle/src/routes/+layout.server.ts
@@ -9,35 +9,36 @@ export const load: LayoutServerLoad = async ({ locals, cookies }) => {
 	let groupInviteCount = 0;
 	let userGroups: { id: string; name: string }[] = [];
 	if (user) {
-		const { data: profile } = await locals.supabase
-			.from('profiles')
-			.select('username, avatar_url')
-			.eq('id', user.id)
-			.single();
-		avatarUrl = profile?.avatar_url ?? null;
-		username = profile?.username ?? null;
+		const [profileResult, friendCountResult, inviteCountResult, membershipsResult] =
+			await Promise.all([
+				locals.supabase
+					.from('profiles')
+					.select('username, avatar_url')
+					.eq('id', user.id)
+					.single(),
+				locals.supabase
+					.from('friendships')
+					.select('id', { count: 'exact', head: true })
+					.eq('addressee_id', user.id)
+					.eq('status', 'pending'),
+				locals.supabase
+					.from('group_invites')
+					.select('id', { count: 'exact', head: true })
+					.eq('invited_user_id', user.id),
+				locals.supabase
+					.from('group_members')
+					.select('groups(id, name)')
+					.eq('user_id', user.id)
+					.is('left_at', null)
+					.order('joined_at', { ascending: false })
+					.limit(3)
+			]);
 
-		const { count } = await locals.supabase
-			.from('friendships')
-			.select('id', { count: 'exact', head: true })
-			.eq('addressee_id', user.id)
-			.eq('status', 'pending');
-		friendRequestCount = count ?? 0;
-
-		const { count: inviteCount } = await locals.supabase
-			.from('group_invites')
-			.select('id', { count: 'exact', head: true })
-			.eq('invited_user_id', user.id);
-		groupInviteCount = inviteCount ?? 0;
-
-		const { data: memberships } = await locals.supabase
-			.from('group_members')
-			.select('groups(id, name)')
-			.eq('user_id', user.id)
-			.is('left_at', null)
-			.order('joined_at', { ascending: false })
-			.limit(3);
-		userGroups = (memberships ?? [])
+		avatarUrl = profileResult.data?.avatar_url ?? null;
+		username = profileResult.data?.username ?? null;
+		friendRequestCount = friendCountResult.count ?? 0;
+		groupInviteCount = inviteCountResult.count ?? 0;
+		userGroups = (membershipsResult.data ?? [])
 			.map((m) => m.groups as unknown as { id: string; name: string })
 			.filter(Boolean);
 	}

--- a/hubdle/src/routes/groups/[id]/+page.server.ts
+++ b/hubdle/src/routes/groups/[id]/+page.server.ts
@@ -35,20 +35,18 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 					.order('created_at', { ascending: false })
 			: { data: [] };
 
-	const { data: games } = await locals.supabase
-		.from('games')
-		.select('id, name, url, score_direction');
-
-	// Fetch all friendships (accepted + pending) to show status on member list
-	const { data: friendshipsAsRequester } = await locals.supabase
-		.from('friendships')
-		.select('addressee_id, status')
-		.eq('requester_id', user.id);
-
-	const { data: friendshipsAsAddressee } = await locals.supabase
-		.from('friendships')
-		.select('requester_id, status')
-		.eq('addressee_id', user.id);
+	const [{ data: games }, { data: friendshipsAsRequester }, { data: friendshipsAsAddressee }] =
+		await Promise.all([
+			locals.supabase.from('games').select('id, name, url, score_direction'),
+			locals.supabase
+				.from('friendships')
+				.select('addressee_id, status')
+				.eq('requester_id', user.id),
+			locals.supabase
+				.from('friendships')
+				.select('requester_id, status')
+				.eq('addressee_id', user.id)
+		]);
 
 	// Map of user_id -> friendship status for all members
 	const friendshipStatusMap: Record<string, string> = {};

--- a/hubdle/src/routes/users/[username]/+page.server.ts
+++ b/hubdle/src/routes/users/[username]/+page.server.ts
@@ -16,12 +16,6 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 
 	const isOwnProfile = user?.id === profile.id;
 
-	const { count: totalGroups } = await locals.supabase
-		.from('group_members')
-		.select('group_id', { count: 'exact', head: true })
-		.eq('user_id', profile.id)
-		.is('left_at', null);
-
 	const { data: submissions } = await locals.supabase
 		.from('submissions')
 		.select('id, score, game_id, game_date, games(name, score_direction)')
@@ -147,16 +141,18 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 	}
 
 	// Friend count
-	const { count: friendCountAsReq } = await locals.supabase
-		.from('friendships')
-		.select('id', { count: 'exact', head: true })
-		.eq('requester_id', profile.id)
-		.eq('status', 'accepted');
-	const { count: friendCountAsAddr } = await locals.supabase
-		.from('friendships')
-		.select('id', { count: 'exact', head: true })
-		.eq('addressee_id', profile.id)
-		.eq('status', 'accepted');
+	const [{ count: friendCountAsReq }, { count: friendCountAsAddr }] = await Promise.all([
+		locals.supabase
+			.from('friendships')
+			.select('id', { count: 'exact', head: true })
+			.eq('requester_id', profile.id)
+			.eq('status', 'accepted'),
+		locals.supabase
+			.from('friendships')
+			.select('id', { count: 'exact', head: true })
+			.eq('addressee_id', profile.id)
+			.eq('status', 'accepted')
+	]);
 	const friendCount = (friendCountAsReq ?? 0) + (friendCountAsAddr ?? 0);
 
 	return {


### PR DESCRIPTION
## Summary
- Parallelize independent Supabase queries in root layout, group detail, and profile page server load functions using `Promise.all()` — eliminates waterfall DB requests that added seconds to every page load on cold starts
- Remove unused `totalGroups` query on the profile page

## Test plan
- [ ] Verify all pages load correctly (games, groups, group detail, user profiles)
- [ ] Check navbar still shows correct friend request count, group invite count, and user groups
- [ ] Confirm group detail page shows correct members, submissions, and friendship statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)